### PR TITLE
Allow to add annotations to Zot Service

### DIFF
--- a/charts/zot/Chart.yaml
+++ b/charts/zot/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: v2.0.0-rc6
 description: A Helm chart for Kubernetes
 name: zot
 type: application
-version: 0.1.26
+version: 0.1.27

--- a/charts/zot/templates/service.yaml
+++ b/charts/zot/templates/service.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "zot.fullname" . }}
   labels:
     {{- include "zot.labels" . | nindent 4 }}
+{{- with .Values.service.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/zot/values.yaml
+++ b/charts/zot/values.yaml
@@ -18,6 +18,8 @@ serviceAccount:
 service:
   type: NodePort
   port: 5000
+  # Annotations to add to the service
+  annotations: {}
 # Enabling this will publicly expose your zot server
 # Only enable this if you have security enabled on your cluster
 ingress:


### PR DESCRIPTION
Hi :wave: 

In order to integrate with an external tool ([external-dns](https://kubernetes-sigs.github.io/external-dns/) in my case) I need to specify some annotations on the Zot service.
Unfortunately this is currently not supported on the Helm Chart.

This PR allows to add annotations to the service.

