### PR TITLE
feat: allow to mount external secret to /secret

### DIFF
--- a/charts/zot/Chart.yaml
+++ b/charts/zot/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: v2.0.0-rc6
 description: A Helm chart for Kubernetes
 name: zot
 type: application
-version: 0.1.27
+version: 0.1.28

--- a/charts/zot/templates/_helpers.tpl
+++ b/charts/zot/templates/_helpers.tpl
@@ -60,3 +60,10 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Create the name of the secret to use
+*/}}
+{{- define "zot.secretName" -}}
+{{- default ( printf "%s-secret" .Release.Name ) .Values.secretFilesSecretName }}
+{{- end }}

--- a/charts/zot/templates/deployment.yaml
+++ b/charts/zot/templates/deployment.yaml
@@ -35,15 +35,15 @@ spec:
             - name: zot
               containerPort: 5000
               protocol: TCP
-          {{- if or .Values.mountConfig .Values.mountSecret .Values.persistence }}
+          {{- if or .Values.mountConfig .Values.mountSecret .Values.persistence .Values.secretFilesSecretName }}
           volumeMounts:
           {{- if .Values.mountConfig }}
             - mountPath: '/etc/zot'
               name: {{ .Release.Name }}-config
           {{- end }}
-          {{- if .Values.mountSecret }}
+          {{- if or .Values.mountSecret .Values.secretFilesSecretName }}
             - mountPath: '/secret'
-              name: {{ .Release.Name }}-secret
+              name: {{ include "zot.secretName" . }}
           {{- end }}
           {{- if .Values.persistence }}
             - mountPath: '/var/lib/registry'
@@ -81,10 +81,10 @@ spec:
           configMap:
             name: {{ .Release.Name }}-config
       {{- end }}
-      {{- if .Values.mountSecret }}
-        - name: {{ .Release.Name }}-secret
+      {{- if or .Values.mountSecret .Values.secretFilesSecretName }}
+        - name: {{ include "zot.secretName" . }}
           secret:
-            secretName: {{ .Release.Name }}-secret
+            secretName: {{ include "zot.secretName" . }}
       {{- end }}
       {{- if .Values.persistence }}
         - name: {{ .Release.Name }}-volume

--- a/charts/zot/templates/secret.yaml
+++ b/charts/zot/templates/secret.yaml
@@ -1,8 +1,8 @@
-{{- if and .Values.mountSecret .Values.secretFiles }}
+{{- if and .Values.mountSecret .Values.secretFiles ( not .Values.secretFilesSecretName ) }}
 apiVersion: v1
 kind: Secret
 metadata:
-  name: {{ .Release.Name }}-secret
+  name: {{ include "zot.secretName" . }}
 type: Opaque
 data:
 {{- range $key, $val := .Values.secretFiles }}

--- a/charts/zot/values.yaml
+++ b/charts/zot/values.yaml
@@ -84,6 +84,12 @@ configFiles:
 #      "log": { "level": "debug" }
 #    }
 
+# if secretFilesSecretName is not empty, the Secret named
+# $secretFilesSecretName is mounted on the pod's '/secret' directory (it is
+# used to keep files with passwords, like a `htpasswd` file).
+# In this case, below 'mountSecret' and 'secretFiles' values are not taken
+# into account.
+secretFilesSecretName: ""
 # If mountSecret is true, the Secret named $CHART_RELEASE-secret is mounted on
 # the pod's '/secret' directory (it is used to keep files with passwords, like
 # a `htpasswd` file)


### PR DESCRIPTION
added a new `secretFilesSecretName` value. If it is not empty, the secret named `$secretFilesSecretName` is mounted on the pod's `/secret` directory. In this case, `mountSecret` and `secretFiles` values are not taken into account.

Chart version bumped to `0.1.28`.

Fixes #10