### PR TITLE
feat: allow to mount several external secrets

### DIFF
--- a/charts/zot/Chart.yaml
+++ b/charts/zot/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: v2.0.0-rc6
 description: A Helm chart for Kubernetes
 name: zot
 type: application
-version: 0.1.27
+version: 0.1.28

--- a/charts/zot/templates/deployment.yaml
+++ b/charts/zot/templates/deployment.yaml
@@ -35,7 +35,7 @@ spec:
             - name: zot
               containerPort: 5000
               protocol: TCP
-          {{- if or .Values.mountConfig .Values.mountSecret .Values.persistence }}
+          {{- if or .Values.mountConfig .Values.mountSecret .Values.persistence .Values.externalSecrets }}
           volumeMounts:
           {{- if .Values.mountConfig }}
             - mountPath: '/etc/zot'
@@ -44,6 +44,10 @@ spec:
           {{- if .Values.mountSecret }}
             - mountPath: '/secret'
               name: {{ .Release.Name }}-secret
+          {{- end }}
+          {{- range .Values.externalSecrets }}
+            - mountPath: {{ .mountPath | quote }}
+              name: {{ .secretName | quote }}
           {{- end }}
           {{- if .Values.persistence }}
             - mountPath: '/var/lib/registry'
@@ -74,7 +78,7 @@ spec:
               {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-      {{- if or .Values.mountConfig .Values.persistence }}
+      {{- if or .Values.mountConfig .Values.persistence .Values.externalSecrets }}
       volumes:
       {{- if .Values.mountConfig }}
         - name: {{ .Release.Name }}-config
@@ -85,6 +89,11 @@ spec:
         - name: {{ .Release.Name }}-secret
           secret:
             secretName: {{ .Release.Name }}-secret
+      {{- end }}
+      {{- range .Values.externalSecrets }}
+        - name: {{ .secretName }}
+          secret:
+            secretName: {{ .secretName }}
       {{- end }}
       {{- if .Values.persistence }}
         - name: {{ .Release.Name }}-volume

--- a/charts/zot/values.yaml
+++ b/charts/zot/values.yaml
@@ -84,6 +84,21 @@ configFiles:
 #      "log": { "level": "debug" }
 #    }
 
+# externalSecrets allows to mount external (meaning not managed by this chart)
+# Kubernetes secrets within the Zot container.
+# The secret is identified by its name (property "secretName") and should be
+# present in the same namespace. The property "mountPath" specifies the path
+# within the container filesystem where the secret is mounted.
+#
+# Below is an example:
+#
+#  externalSecrets:
+#  - secretName: "secret1"
+#    mountPath: "/secrets/s1"
+#  - secretName: "secret2"
+#    mountPath: "/secrets/s2"
+externalSecrets: []
+
 # If mountSecret is true, the Secret named $CHART_RELEASE-secret is mounted on
 # the pod's '/secret' directory (it is used to keep files with passwords, like
 # a `htpasswd` file)


### PR DESCRIPTION
## Description of changes

added a new `externalSecrets` value. This value is a list of tuples that
defines a "secretName" and a "mountPath". "secretName" references
a secret within the same namespace than the Zot container and
"mountPath" specifies the path within the container filesystem where
the secret is mounted.

Chart version bumped to `0.1.29`.

Fixes #10

I already proposed PR #11 to fix #10, but my personal preference goes to this PR.

To be noted that this PR has 0 impacts on `mountSecret` and `secretFiles` and can be use along with them.

## How to use it

Within `values.yaml`, `externalSecrets` can be speficied this way:

```yaml
externalSecrets:
  - secretName: "secret1"
    mountPath: "/secrets/s1"
  - secretName: "secret2"
    mountPath: "/secrets/s2"
```

A command line flags equivalent would be:

```bash
--set externalSecrets.0.secretName=secret1 --set externalSecrets.0.mountPath=/secrets/s1 --set externalSecrets.1.secretName=secret2 --set externalSecrets.1.mountPath=/secrets/s2
```