### PR TITLE
fix: missing secret volume when only `mountSecret`

### DIFF
--- a/charts/zot/Chart.yaml
+++ b/charts/zot/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: v2.0.0-rc6
 description: A Helm chart for Kubernetes
 name: zot
 type: application
-version: 0.1.27
+version: 0.1.28

--- a/charts/zot/templates/deployment.yaml
+++ b/charts/zot/templates/deployment.yaml
@@ -74,7 +74,7 @@ spec:
               {{- end }}
           resources:
             {{- toYaml .Values.resources | nindent 12 }}
-      {{- if or .Values.mountConfig .Values.persistence }}
+      {{- if or .Values.mountConfig .Values.mountSecret .Values.persistence }}
       volumes:
       {{- if .Values.mountConfig }}
         - name: {{ .Release.Name }}-config


### PR DESCRIPTION
Fixes #13

Secret volume is now defined when `mountSecret` is set to `true` but not `mountConfig` or `persistence`

Here is the result of the template command after applying this fix:

```bash
$ helm template zot charts/zot --set mountSecret=true -s templates/deployment.yaml
---
# Source: zot/templates/deployment.yaml
apiVersion: apps/v1
kind: Deployment
metadata:
  name: zot
  labels:
    helm.sh/chart: zot-0.1.28
    app.kubernetes.io/name: zot
    app.kubernetes.io/instance: zot
    app.kubernetes.io/version: "v2.0.0-rc6"
    app.kubernetes.io/managed-by: Helm
spec:
  replicas: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: zot
      app.kubernetes.io/instance: zot
  template:
    metadata:
      labels:
        app.kubernetes.io/name: zot
        app.kubernetes.io/instance: zot
    spec:
      serviceAccountName: zot
      securityContext:
        null
      containers:
        - name: zot
          securityContext:
            null
          image: "ghcr.io/project-zot/zot-linux-amd64:v2.0.0-rc6"
          imagePullPolicy: IfNotPresent
          ports:
            - name: zot
              containerPort: 5000
              protocol: TCP
          volumeMounts:
            - mountPath: '/secret'
              name: zot-secret
          livenessProbe:
            initialDelaySeconds: 5
            httpGet:
              path: /v2/
              port: 5000
              scheme: HTTP
          readinessProbe:
            initialDelaySeconds: 5
            httpGet:
              path: /v2/
              port: 5000
              scheme: HTTP
          resources:
            null
      volumes:
        - name: zot-secret
          secret:
            secretName: zot-secret
```

