### PR TITLE
feat: ability to choose specific service nodePort

### DIFF
--- a/charts/zot/templates/service.yaml
+++ b/charts/zot/templates/service.yaml
@@ -15,5 +15,8 @@ spec:
       targetPort: zot
       protocol: TCP
       name: zot
+      {{- if .Values.service.nodePort }}
+      nodePort: {{ .Values.service.nodePort }}
+      {{- end }}
   selector:
     {{- include "zot.selectorLabels" . | nindent 4 }}

--- a/charts/zot/values.yaml
+++ b/charts/zot/values.yaml
@@ -18,6 +18,7 @@ serviceAccount:
 service:
   type: NodePort
   port: 5000
+  nodePort: null # Set to a specific port if type is NodePort
   # Annotations to add to the service
   annotations: {}
 # Enabling this will publicly expose your zot server


### PR DESCRIPTION
While using service type=LB, it's very useful to choose a specific nodePort (instead of having a random one assigned).

https://kubernetes.io/docs/concepts/services-networking/service/#type-nodeport