### PR TITLE
fix: Add ability to set envirnment variables in deployment

### DIFF
--- a/charts/zot/Chart.yaml
+++ b/charts/zot/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: v2.0.0-rc6
 description: A Helm chart for Kubernetes
 name: zot
 type: application
-version: 0.1.29
+version: 0.1.30

--- a/charts/zot/templates/deployment.yaml
+++ b/charts/zot/templates/deployment.yaml
@@ -31,6 +31,8 @@ spec:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          env:
+            {{- toYaml .Values.env | nindent 12 }}          
           ports:
             - name: zot
               containerPort: 5000

--- a/charts/zot/values.yaml
+++ b/charts/zot/values.yaml
@@ -135,3 +135,13 @@ pvc:
   storage: 8Gi
   # Name of the storage class to use if it is different than the default one
   storageClassName: null
+
+# List of environment variables to set on the container
+env:
+# - name: "TEST"
+#  value: "ME"
+# - name: SECRET_NAME
+#  valueFrom:
+#    secretKeyRef:
+#      name: mysecret
+#      key: username


### PR DESCRIPTION
This is a re-do of #16, I had trouble getting my commits correct and had to start over.  I hope this works.  I will repeat the change description from #16 here for reference:

I use a Rook-Ceph objectbucketclaim (OBC) to create an s3 bucket in my cluster. The OBC will create a secret that looks something like the following:

```yaml
apiVersion: v1
data:
  AWS_ACCESS_KEY_ID: <my-id>
  AWS_SECRET_ACCESS_KEY: <my-key>
kind: Secret
metadata:
  finalizers:
  - objectbucket.io/finalizer
  labels:
    bucket-provisioner: rook-ceph.ceph.rook.io-bucket
  name: zot
  namespace: zot
  ownerReferences:
  - apiVersion: objectbucket.io/v1alpha1
    blockOwnerDeletion: true
    controller: true
    kind: ObjectBucketClaim
    name: zot
    uid: 25b2f0e5-a0ad-4ddb-95fb-07527a82a32b
  resourceVersion: "226903046"
  uid: 8b2523ba-ebbb-4d1d-961c-be9222b092d5
type: Opaque
```

As a result I need the ability to set the `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` environment variables in the zot deployment using this secret.  With this PR I will be able to set the following values to achieve this:


```yaml
env:          
- name: AWS_ACCESS_KEY_ID
  valueFrom:
    secretKeyRef:
      name: zot
      key: AWS_ACCESS_KEY_ID
- name: AWS_SECRET_ACCESS_KEY
  valueFrom:
    secretKeyRef:
      name: zot
      key: AWS_SECRET_ACCESS_KEY
```
