### PR TITLE
feat: Allow static clusterIP in service definition

### DIFF
--- a/charts/zot/Chart.yaml
+++ b/charts/zot/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: v2.0.0-rc6
 description: A Helm chart for Kubernetes
 name: zot
 type: application
-version: 0.1.33
+version: 0.1.34

--- a/charts/zot/ci/static-cluster-ip-values.yaml
+++ b/charts/zot/ci/static-cluster-ip-values.yaml
@@ -1,0 +1,3 @@
+service:
+  type: ClusterIP
+  clusterIP: 10.96.0.15

--- a/charts/zot/templates/service.yaml
+++ b/charts/zot/templates/service.yaml
@@ -10,6 +10,9 @@ metadata:
 {{- end }}
 spec:
   type: {{ .Values.service.type }}
+  {{- if and .Values.service.clusterIP ( eq .Values.service.type "ClusterIP" ) }}
+  clusterIP: {{ .Values.service.clusterIP }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: zot

--- a/charts/zot/values.yaml
+++ b/charts/zot/values.yaml
@@ -21,6 +21,9 @@ service:
   nodePort: null  # Set to a specific port if type is NodePort
   # Annotations to add to the service
   annotations: {}
+  # Set to a static IP if a static IP is desired, only works when
+  # type: ClusterIP
+  clusterIP: null
 # Enabling this will publicly expose your zot server
 # Only enable this if you have security enabled on your cluster
 ingress:


### PR DESCRIPTION
Hi,

For my usecase I'd like to be able to specify a static clusterIP in the helm chart. I believe the following PR achieves that. Let me know if I need to change up some bits before approval.