### PR TITLE
feat: auto restart deployment when config files change

### DIFF
--- a/charts/zot/Chart.yaml
+++ b/charts/zot/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: v2.0.1
 description: A Helm chart for Kubernetes
 name: zot
 type: application
-version: 0.1.46
+version: 0.1.47

--- a/charts/zot/templates/deployment.yaml
+++ b/charts/zot/templates/deployment.yaml
@@ -11,10 +11,13 @@ spec:
       {{- include "zot.selectorLabels" . | nindent 6 }}
   template:
     metadata:
-      {{- with .Values.podAnnotations }}
       annotations:
+        {{- with .Values.podAnnotations }}
         {{- toYaml . | nindent 8 }}
-      {{- end }}
+        {{- end }}
+        {{- if and .Values.mountConfig .Values.configFiles }}
+        checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
+        {{- end }}
       labels:
         {{- include "zot.selectorLabels" . | nindent 8 }}
     spec:

--- a/charts/zot/unittests/configmap_checksum_test.yaml
+++ b/charts/zot/unittests/configmap_checksum_test.yaml
@@ -1,0 +1,23 @@
+suite: configmap checksum in deployment
+# Can't use global templates in this test suite as it will break the checksum calculation
+# causing false negative test outcome.
+# templates:
+#   - deployment.yaml
+tests:
+  - it: has no checksum/config if no config
+    template: deployment.yaml
+    asserts:
+      - isNull:
+          path: spec.template.metadata.annotations.checksum/config
+  - it: generate checksum/config if config is present
+    template: deployment.yaml
+    set:
+      mountConfig: true
+      configFiles:
+        config.json: "{}"
+    asserts:
+      - isNotNull:
+          path: spec.template.metadata.annotations.checksum/config
+      - matchRegex:
+          path: spec.template.metadata.annotations.checksum/config
+          pattern: "^[a-f0-9]{64}$" # SHA256 hex output

--- a/charts/zot/values.yaml
+++ b/charts/zot/values.yaml
@@ -171,3 +171,5 @@ extraVolumeMounts: []
 extraVolumes: []
 # - name: data
 #   emptyDir: {}
+
+podAnnotations: {}


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

feature

**What does this PR do / Why do we need it**:

This PR ensure when the `configFiles` changes and `mountConfig` is true, zot deployment will be automatically restarted.

This will eliminate the manual zot restart step after config change.

This is done per [helm's official best practice guide](https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments).

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

Unit test added.

**Automation added to e2e**:

N/A

**Will this break upgrades or downgrades?**

- No.


**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
Changing config files will now automatically restart Zot's deployment.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
