### PR TITLE
feat: add support for more deployment configuration

### DIFF
--- a/charts/zot/Chart.yaml
+++ b/charts/zot/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: v2.0.3
 description: A Helm chart for Kubernetes
 name: zot
 type: application
-version: 0.1.53
+version: 0.1.54

--- a/charts/zot/templates/deployment.yaml
+++ b/charts/zot/templates/deployment.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "zot.fullname" . }}
   labels:
     {{- include "zot.labels" . | nindent 4 }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   {{- with .Values.strategy }}
@@ -27,6 +31,9 @@ spec:
         {{- end }}
       labels:
         {{- include "zot.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -35,12 +42,19 @@ spec:
       serviceAccountName: {{ include "zot.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.extraArgs }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             {{- toYaml .Values.env | nindent 12 }}
           ports:
@@ -144,3 +158,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      dnsPolicy: {{ .Values.dnsPolicy }}

--- a/charts/zot/values.yaml
+++ b/charts/zot/values.yaml
@@ -178,4 +178,17 @@ strategy:
 #  rollingUpdate:
 #    maxUnavailable: 25%
 
+# Extra args to pass to the deployment's container
+extraArgs: []
+
 podAnnotations: {}
+
+podLabels: {}
+
+deploymentAnnotations: {}
+
+priorityClassName: ""
+
+dnsConfig: {}
+
+dnsPolicy: "ClusterFirst"


### PR DESCRIPTION
Adds some standard deployment configuration values such as deployment annotations, priorityClassName, and extraArgs for the container.

**What type of PR is this?**

feature

**Which issue does this PR fix**:

N/A

**What does this PR do / Why do we need it**:

Adding some common helm values for configuring the deployment that we need.


**Testing done on this change**:

Manually ran helm template on the chart to ensure that the values are being set properly


**Will this break upgrades or downgrades?**
No

**Does this PR introduce any user-facing change?**:


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
