### PR TITLE
feat: auto restart deployment when secret files change

### DIFF
--- a/charts/zot/Chart.yaml
+++ b/charts/zot/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: v2.1.0
 description: A Helm chart for Kubernetes
 name: zot
 type: application
-version: 0.1.57
+version: 0.1.58

--- a/charts/zot/templates/deployment.yaml
+++ b/charts/zot/templates/deployment.yaml
@@ -22,6 +22,9 @@ spec:
         {{- if and .Values.mountConfig .Values.configFiles }}
         checksum/config: {{ include (print $.Template.BasePath "/configmap.yaml") . | sha256sum }}
         {{- end }}
+        {{- if and .Values.mountSecret .Values.secretFiles }}
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
+        {{- end }}
         {{- if .Values.forceRoll }}
         rollme: {{ randAlphaNum 5 | quote }}
         {{- end }}

--- a/charts/zot/unittests/secret_checksum_test.yaml
+++ b/charts/zot/unittests/secret_checksum_test.yaml
@@ -1,0 +1,25 @@
+suite: secret checksum in deployment
+# Can't use global templates in this test suite as it will break the checksum calculation
+# causing false negative test outcome.
+# templates:
+#   - deployment.yaml
+tests:
+  - it: has no checksum/secret if no config
+    template: deployment.yaml
+    asserts:
+      - isNull:
+          path: spec.template.metadata.annotations.checksum/secret
+  - it: generate checksum/secret if config is present
+    template: deployment.yaml
+    set:
+      mountSecret: true
+      secretFiles:
+        htpasswd: |-
+          admin:$2y$05$vmiurPmJvHylk78HHFWuruFFVePlit9rZWGA/FbZfTEmNRneGJtha
+          user:$2y$05$L86zqQDfH5y445dcMlwu6uHv.oXFgT6AiJCwpv3ehr7idc0rI3S2G
+    asserts:
+      - isNotNull:
+          path: spec.template.metadata.annotations.checksum/secret
+      - matchRegex:
+          path: spec.template.metadata.annotations.checksum/secret
+          pattern: "^[a-f0-9]{64}$" # SHA256 hex output

--- a/charts/zot/values.yaml
+++ b/charts/zot/values.yaml
@@ -63,9 +63,7 @@ startupProbe:
 mountConfig: false
 # If mountConfig is true the chart creates the '$CHART_RELEASE-config', if it
 # does not exist the user is in charge of managing it (as this file includes a
-# sample file you have to add it empty to handle it externally) ... note that
-# the service does not reload the configFiles once mounted, so you need to
-# delete the pods to create new ones to use the new values.
+# sample file you have to add it empty to handle it externally).
 configFiles:
   config.json: |-
     {


### PR DESCRIPTION
**What type of PR is this?**

feature

**What does this PR do / Why do we need it:**

This PR ensure when the `secretFiles` changes and `mountSecret` is true, zot deployment will be automatically restarted.

This will eliminate the manual zot restart step after secrets change.

This is done per [helm's official best practice guide](https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments).

This is very similar to what https://github.com/project-zot/helm-charts/pull/36 achieved just for secrets.

Additionally I fixed the comment for the `.configFiles` Helm value as the reload was fixed in the above PR.

**Testing done on this change:**

Unit test added.

**Automation added to e2e:**

N/A

**Will this break upgrades or downgrades?**

No.

**Does this PR introduce any user-facing change?:**

Changing secret files will now automatically restart Zot's deployment.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.