### PR TITLE
feat: add support for more deployment configuration

### DIFF
--- a/charts/zot/Chart.yaml
+++ b/charts/zot/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: v2.1.2-rc2
 description: A Helm chart for Kubernetes
 name: zot
 type: application
-version: 0.1.62
+version: 0.1.63

--- a/charts/zot/templates/deployment.yaml
+++ b/charts/zot/templates/deployment.yaml
@@ -4,6 +4,10 @@ metadata:
   name: {{ include "zot.fullname" . }}
   labels:
     {{- include "zot.labels" . | nindent 4 }}
+  {{- with .Values.deploymentAnnotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   replicas: {{ .Values.replicaCount }}
   {{- with .Values.strategy }}
@@ -30,6 +34,9 @@ spec:
         {{- end }}
       labels:
         {{- include "zot.selectorLabels" . | nindent 8 }}
+        {{- with .Values.podLabels }}
+        {{- toYaml . | nindent 8 }}
+        {{- end }}
     spec:
       {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -38,12 +45,19 @@ spec:
       serviceAccountName: {{ include "zot.serviceAccountName" . }}
       securityContext:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      {{- with .Values.priorityClassName }}
+      priorityClassName: {{ . }}
+      {{- end }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:
             {{- toYaml .Values.securityContext | nindent 12 }}
           image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
           imagePullPolicy: {{ .Values.image.pullPolicy }}
+          {{- with .Values.extraArgs }}
+          args:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
           env:
             {{- toYaml .Values.env | nindent 12 }}
           ports:
@@ -147,3 +161,8 @@ spec:
       tolerations:
         {{- toYaml . | nindent 8 }}
       {{- end }}
+      {{- with .Values.dnsConfig }}
+      dnsConfig:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      dnsPolicy: {{ .Values.dnsPolicy }}

--- a/charts/zot/values.yaml
+++ b/charts/zot/values.yaml
@@ -176,7 +176,21 @@ strategy:
 #  rollingUpdate:
 #    maxUnavailable: 25%
 
+# Extra args to pass to the deployment's container
+extraArgs: []
+
 podAnnotations: {}
+
+podLabels: {}
+
+deploymentAnnotations: {}
+
+priorityClassName: ""
+
+dnsConfig: {}
+
+dnsPolicy: "ClusterFirst"
+
 # Metrics configuration
 # NOTE: need enable metric extension in config.json
 metrics:


### PR DESCRIPTION
Adds some standard deployment configuration values such as deployment annotations, priorityClassName, pod labels, dns configuration, and extraArgs for
the container.

(cherry picked from commit fc94e6bd741be8b19ff103d36de74ca9e0b779ce)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
