### PR TITLE
chore: upgrade to actions/upload-artifact@v4

### DIFF
--- a/.github/workflows/scorecards.yml
+++ b/.github/workflows/scorecards.yml
@@ -49,7 +49,7 @@ jobs:
       # Upload the results as artifacts (optional). Commenting out will disable uploads of run results in SARIF
       # format to the repository Actions tab.
       - name: "Upload artifact"
-        uses: actions/upload-artifact@v3 # v3.0.0
+        uses: actions/upload-artifact@v4
         with:
           name: SARIF file
           path: results.sarif


### PR DESCRIPTION
Artifact actions v3 will be closing down by January 30, 2025.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
