### PR TITLE
feat: Add support for configuring service.internalTrafficPolicy

### DIFF
--- a/charts/zot/templates/service.yaml
+++ b/charts/zot/templates/service.yaml
@@ -14,6 +14,9 @@ spec:
   {{- if and .Values.service.clusterIP ( eq .Values.service.type "ClusterIP" ) }}
   clusterIP: {{ .Values.service.clusterIP }}
   {{- end }}
+  {{- if .Values.service.internalTrafficPolicy }}
+  internalTrafficPolicy: {{ .Values.service.internalTrafficPolicy }}
+  {{- end }}
   ports:
     - port: {{ .Values.service.port }}
       targetPort: zot

--- a/charts/zot/values.yaml
+++ b/charts/zot/values.yaml
@@ -26,6 +26,8 @@ service:
   # Set to a static IP if a static IP is desired, only works when
   # type: ClusterIP
   clusterIP: null
+  # Specify how internal traffic is handled (Cluster or Local)
+  internalTrafficPolicy: null
 # Enabling this will publicly expose your zot server
 # Only enable this if you have security enabled on your cluster
 ingress:


### PR DESCRIPTION
I deploy zot and a remote buildkit agent to be co-located on the same
node, and I'd like to be able to set the `internalTrafficPolicy` so that
when I target `zot.default` for my registry, that I my traffic stays
within the same node.
