### PR TITLE
feat: added basicAuth into the serviceMonitor manifest

### DIFF
--- a/charts/zot/Chart.yaml
+++ b/charts/zot/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: v2.1.2
 description: A Helm chart for Kubernetes
 name: zot
 type: application
-version: 0.1.68
+version: 0.1.69

--- a/charts/zot/templates/servicemonitor.yaml
+++ b/charts/zot/templates/servicemonitor.yaml
@@ -30,6 +30,15 @@ spec:
       {{- if .Values.metrics.serviceMonitor.scheme }}
       scheme: {{ .Values.metrics.serviceMonitor.scheme }}
       {{- end }}
+      {{- if .Values.metrics.serviceMonitor.basicAuth }}
+      basicAuth:
+        password:
+          name: {{ .Values.metrics.serviceMonitor.basicAuth.secretName }}
+          key: {{ .Values.metrics.serviceMonitor.basicAuth.passwordKey }}
+        username:
+          name: {{ .Values.metrics.serviceMonitor.basicAuth.secretName }}
+          key: {{ .Values.metrics.serviceMonitor.basicAuth.userKey }}
+      {{- end }}
   namespaceSelector:
     matchNames:
       - {{ .Release.Namespace }}

--- a/charts/zot/values.yaml
+++ b/charts/zot/values.yaml
@@ -199,6 +199,11 @@ metrics:
     interval: "30s"
     # Specify the path to scrape metrics from
     path: "/metrics"
+    # basicAuth credentials for serviceMonitor
+    basicAuth:
+      secretName: basic-auth
+      usernameKey: username
+      passwordKey: password
 
 # Test hooks configuration
 test:


### PR DESCRIPTION
**What type of PR is this?**
feature

**Which issue does this PR fix**:
#59 

**What does this PR do / Why do we need it**:
Allow collection of metrics with basic Auth enabled

**Will this break upgrades or downgrades?**
No, it only adds extra options if added to values file

**Does this PR introduce any user-facing change?**:
```release-note
Added option to allow serviceMonitor to use a secret with username and password for autthentication against metrics endpoint
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
