### PR TITLE
feat: added defaults for the secrets keys for basicauth in the servic…

### DIFF
--- a/charts/zot/Chart.yaml
+++ b/charts/zot/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: v2.1.2
 description: A Helm chart for Kubernetes
 name: zot
 type: application
-version: 0.1.69
+version: 0.1.70

--- a/charts/zot/templates/servicemonitor.yaml
+++ b/charts/zot/templates/servicemonitor.yaml
@@ -34,10 +34,10 @@ spec:
       basicAuth:
         password:
           name: {{ .Values.metrics.serviceMonitor.basicAuth.secretName }}
-          key: {{ .Values.metrics.serviceMonitor.basicAuth.passwordKey }}
+          key: {{ .Values.metrics.serviceMonitor.basicAuth.passwordKey | default ("password") }}
         username:
           name: {{ .Values.metrics.serviceMonitor.basicAuth.secretName }}
-          key: {{ .Values.metrics.serviceMonitor.basicAuth.userKey }}
+          key: {{ .Values.metrics.serviceMonitor.basicAuth.usernameKey | default ("username") }}
       {{- end }}
   namespaceSelector:
     matchNames:


### PR DESCRIPTION
…emonitor

**What type of PR is this?**
feature

**What does this PR do / Why do we need it**:
It fixes a name issue with value key and added sane defaults to the service monitor basic auth 

**If an issue # is not available, please add repo steps and logs showing the issue**:

**Does this PR introduce any user-facing change?**:
no, it fixes a naming issue in the template and add defaults to the basic auth

```release-note
discoverd a mismatch between the value key in the template vs values file and fixed it.
also added defaults for the basic auth keys to look for in the secret
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
