### PR TITLE
feature: Add support for hostNetwork

### DIFF
--- a/charts/zot/templates/deployment.yaml
+++ b/charts/zot/templates/deployment.yaml
@@ -50,6 +50,7 @@ spec:
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      hostNetwork: {{ .Values.hostNetwork }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/zot/templates/statefulset.yaml
+++ b/charts/zot/templates/statefulset.yaml
@@ -63,6 +63,7 @@ spec:
       {{- with .Values.priorityClassName }}
       priorityClassName: {{ . }}
       {{- end }}
+      hostNetwork: {{ .Values.hostNetwork }}
       containers:
         - name: {{ .Chart.Name }}
           securityContext:

--- a/charts/zot/values.yaml
+++ b/charts/zot/values.yaml
@@ -26,6 +26,8 @@ service:
   # Set to a static IP if a static IP is desired, only works when
   # type: ClusterIP
   clusterIP: null
+# Set to true if host network should be enabled for zot-registry pod
+hostNetwork: false
 # Enabling this will publicly expose your zot server
 # Only enable this if you have security enabled on your cluster
 ingress:


### PR DESCRIPTION
This adds the "hostNetwork" option to the Deployment used for the zot chart in order to enable/disable that feature.
This allows you to enable host networking for the zot-registry deployment or statefulset.
