### PR TITLE
feat: Add headless service

### DIFF
--- a/charts/zot/Chart.yaml
+++ b/charts/zot/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: v2.1.5
 description: A Helm chart for Kubernetes
 name: zot
 type: application
-version: 0.1.74
+version: 0.1.75

--- a/charts/zot/templates/headless-service.yaml
+++ b/charts/zot/templates/headless-service.yaml
@@ -1,0 +1,23 @@
+{{- if and .Values.serviceHeadless .Values.serviceHeadless.enabled .Values.persistence -}}
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "zot.fullname" . }}-headless
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "zot.labels" . | nindent 4 }}
+{{- with .Values.serviceHeadless.annotations }}
+  annotations:
+{{ toYaml . | indent 4 }}
+{{- end }}
+spec:
+  type: ClusterIP
+  clusterIP: None
+  ports:
+    - port: {{ .Values.serviceHeadless.port }}
+      targetPort: zot
+      protocol: TCP
+      name: zot
+  selector:
+    {{- include "zot.selectorLabels" . | nindent 4 }}
+{{- end -}}

--- a/charts/zot/templates/statefulset.yaml
+++ b/charts/zot/templates/statefulset.yaml
@@ -11,6 +11,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+  {{- if and .Values.serviceHeadless .Values.serviceHeadless.enabled }}
+  serviceName: {{ include "zot.fullname" . }}-headless
+  {{- end }}
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:

--- a/charts/zot/unittests/statefulset_test.yaml
+++ b/charts/zot/unittests/statefulset_test.yaml
@@ -94,3 +94,13 @@ tests:
       - equal:
           path: spec.volumeClaimTemplates[0].metadata.name
           value: custom-pvc-pvc
+  
+  - it: should have an headless service when enabled
+    set:
+      persistence: true
+      serviceHeadless:
+        enabled: true
+    asserts:
+      - matchRegex:
+          path: spec.serviceName
+          pattern: .*-headless$

--- a/charts/zot/values.yaml
+++ b/charts/zot/values.yaml
@@ -17,6 +17,13 @@ serviceAccount:
   # The name of the service account to use.
   # If not set and create is true, a name is generated using the fullname template
   name: ""
+serviceHeadless:
+  # Enable headless service, only for statefulset
+  enabled: false
+  # Headless service port
+  port: 5000
+  # Annotations to add to the headless service
+  annotations: {}
 service:
   type: NodePort
   port: 5000


### PR DESCRIPTION
Hello,


<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

feature

**Which issue does this PR fix**:

**What does this PR do / Why do we need it**:

I am trying to setup Zot in a HA configuration as explained in the documentation https://zotregistry.dev/v2.1.5/articles/high-availability/
However it is not possible to set an address for one of the pod directly in the configuration as a normal service does not allow reolving pods directly.
By adding a Headless Service it is possible and a configuration with an address like this one "http://zot-0.zot-headless.namespace.svc.cluster.local:5000" in the sync configuration will work.

**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
Add unittest
Test with values:

```
replicaCount: 2
mountConfig: true
configFiles:
  config.json: |-
    {
      "storage": { "rootDirectory": "/var/lib/registry" },
      "http": { "address": "0.0.0.0", "port": "5000" },
      "log": { "level": "debug" },
      "extensions": {
        "sync": {
          "registries": [
            {
              "urls": [
                "http://zot-0.zot-headless.registry.svc.cluster.local:5000"
              ],
              "onDemand": false,
              "pollInterval": "2m",
              "maxRetries": 3,
              "retryDelay": "5m",
              "content": [
                {
                  "prefix": "**"
                }
              ]
            }
          ]
        }
      }
    }
persistence: true
pvc:
  create: true
```

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**
No the new service does not have any impact if not used by other application

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
Yes, A new kubernetes service resource will be exposed on the cluster, it can be disabled.

```release-note
Add a Headless Service only with Statefulset that can be disabled.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
