### PR TITLE
feature: publishNotReadyAddresses for headless-service

### DIFF
--- a/charts/zot/Chart.yaml
+++ b/charts/zot/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: v2.1.8
 description: A zot registry helm chart for Kubernetes
 name: zot
 type: application
-version: 0.1.81
+version: 0.1.82

--- a/charts/zot/templates/headless-service.yaml
+++ b/charts/zot/templates/headless-service.yaml
@@ -18,6 +18,7 @@ spec:
       targetPort: zot
       protocol: TCP
       name: zot
+  publishNotReadyAddresses: true
   selector:
     {{- include "zot.selectorLabels" . | nindent 4 }}
 {{- end -}}


### PR DESCRIPTION
**What type of PR is this?**

feature

**Which issue does this PR fix**:

None

**What does this PR do / Why do we need it**:

The headless service is useful for peer discovery in a zot cluster configuration, but the address needs to be resolvable before the pod is ready. This is exactly the purpose of `publishNotReadyAddresses` in the [service spec](https://kubernetes.io/docs/reference/kubernetes-api/service-resources/service-v1/#ServiceSpec).

**Will this break upgrades or downgrades?**

No

**Does this PR introduce any user-facing change?**:

No

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
