### PR TITLE
Allow to set labels on servicemonitor

### DIFF
--- a/charts/zot/Chart.yaml
+++ b/charts/zot/Chart.yaml
@@ -3,4 +3,4 @@ appVersion: v2.1.11
 description: A zot registry helm chart for Kubernetes
 name: zot
 type: application
-version: 0.1.91
+version: 0.1.92

--- a/charts/zot/templates/servicemonitor.yaml
+++ b/charts/zot/templates/servicemonitor.yaml
@@ -8,7 +8,11 @@ metadata:
   name: {{ include "zot.fullname" . }}
   namespace: {{ .Values.namespace | default .Release.Namespace }}
   labels:
+    {{- if .Values.metrics.serviceMonitor.labels }}
+    {{- toYaml .Values.metrics.serviceMonitor.labels | nindent 4 }}
+    {{- else }}
     app.kubernetes.io/component: metrics
+    {{- end }}
 spec:
   {{- if .Values.metrics.serviceMonitor.jobLabel }}
   jobLabel: {{ .Values.metrics.serviceMonitor.jobLabel }}

--- a/charts/zot/unittests/servicemonitor_test.yaml
+++ b/charts/zot/unittests/servicemonitor_test.yaml
@@ -1,0 +1,24 @@
+suite: test servicemonitor
+templates:
+  - servicemonitor.yaml
+tests:
+  - it: should have the default label
+    set:
+      metrics.enabled: true
+      metrics.serviceMonitor.enabled: true
+    asserts:
+      - equal:
+          path: metadata.labels
+          value:
+            app.kubernetes.io/component: metrics
+  - it: should have the overwritten label
+    set:
+      metrics.enabled: true
+      metrics.serviceMonitor.enabled: true
+      metrics.serviceMonitor.labels:
+        test: test
+    asserts:
+      - equal:
+          path: metadata.labels
+          value:
+            test: test

--- a/charts/zot/values.yaml
+++ b/charts/zot/values.yaml
@@ -224,6 +224,8 @@ metrics:
       secretName: basic-auth
       usernameKey: username
       passwordKey: password
+    # Labels to be set in the metadata
+    labels: { }
 # Test hooks configuration
 test:
   image:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

feature

<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:

#91 

**What does this PR do / Why do we need it**:

It allows the user to set the labels of the generated servicemonitor resource. This is needed because Prometheus uses a label selector, but there is no standard label.

**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
```
werner@ip-192-168-0-151-21> helm unittest -f 'charts/zot/unittests/*.yaml' charts/zot

### Chart [ zot ] charts/zot

 PASS  configmap checksum in deployment charts/zot/unittests/configmap_checksum_test.yaml
 PASS  test ingress     charts/zot/unittests/ingress_test.yaml
 PASS  secret checksum in deployment    charts/zot/unittests/secret_checksum_test.yaml
 PASS  test servicemonitor      charts/zot/unittests/servicemonitor_test.yaml
 PASS  statefulset tests        charts/zot/unittests/statefulset_test.yaml

Charts:      1 passed, 1 total
Test Suites: 5 passed, 5 total
Tests:       19 passed, 19 total
Snapshot:    1 passed, 1 total
Time:        28.680084ms
```

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**

No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

Yes

```release-note
The values file now has the property `metrics.serviceMonitor.labels`.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
