### PR TITLE
ci: switch to the newer helm-unittest plugin, and pin helm version

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -22,6 +22,8 @@ jobs:
 
       - name: Install Helm
         uses: azure/setup-helm@v4.3.1
+        with:
+          version: v3.19.4
 
       - uses: actions/setup-python@v6
         with:
@@ -31,7 +33,7 @@ jobs:
       - name: Install helm unittests
         run: |
           helm env
-          helm plugin install https://github.com/quintush/helm-unittest
+          helm plugin install https://github.com/helm-unittest/helm-unittest.git
 
       - name: Install chart-testing
         uses: helm/chart-testing-action@v2.7.0


### PR DESCRIPTION
https://github.com/quintush/helm-unittest is no longer maintained, switch to https://github.com/helm-unittest/helm-unittest.git

We are experiencing https://github.com/helm-unittest/helm-unittest/issues/777.
This is currently not resolved, for now pin helm to the latest v3 release as a workaround.
When the issues above is resolved we should also upgrade helm.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
