### PR TITLE
feat: Add HTTPRoute support for Gateway API

### DIFF
--- a/charts/zot/README.md
+++ b/charts/zot/README.md
@@ -20,6 +20,15 @@ A zot registry helm chart for Kubernetes
 | extraVolumes | list | `[]` |  |
 | httpGet.port | int | `5000` |  |
 | httpGet.scheme | string | `"HTTP"` |  |
+| httproute | object | `{"annotations":{},"enabled":false,"hostnames":[],"labels":{},"parentRefs":[],"path":"/","pathType":"PathPrefix","rules":[]}` | HTTPRoute configuration for Gateway API (alternative to Ingress). Only enable this if you have Gateway API CRDs installed and a Gateway controller. |
+| httproute.annotations | object | `{}` | Annotations to add to the HTTPRoute resource. |
+| httproute.enabled | bool | `false` | Enable HTTPRoute resource creation instead of (or in addition to) Ingress. |
+| httproute.hostnames | list | `[]` | Hostnames to match for this HTTPRoute. |
+| httproute.labels | object | `{}` | Labels to add to the HTTPRoute resource. |
+| httproute.parentRefs | list | `[]` | Gateway references that the HTTPRoute attaches to. At least one parentRef is required when HTTPRoute is enabled. |
+| httproute.path | string | `"/"` | Path to match when custom rules are not specified. |
+| httproute.pathType | string | `"PathPrefix"` | Path matching type (PathPrefix, Exact, or RegularExpression). |
+| httproute.rules | list | `[]` | Advanced routing rules (optional). If not specified, a default rule matching the path will be created. Note: Any backendRefs in custom rules will be ignored and the zot service will always be used. |
 | image.pullPolicy | string | `"IfNotPresent"` |  |
 | image.repository | string | `"ghcr.io/project-zot/zot"` |  |
 | image.tag | string | `"v2.1.15"` |  |

--- a/charts/zot/templates/httproute.yaml
+++ b/charts/zot/templates/httproute.yaml
@@ -1,0 +1,61 @@
+{{- if and .Values.httproute .Values.httproute.enabled -}}
+{{- $fullName := include "zot.fullname" . -}}
+{{- $httpPort := .Values.service.port -}}
+apiVersion: gateway.networking.k8s.io/v1
+kind: HTTPRoute
+metadata:
+  name: {{ $fullName }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "zot.labels" . | nindent 4 }}
+    {{- with .Values.httproute.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.httproute.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if not .Values.httproute.parentRefs }}
+  {{- fail "At least one parentRef is required when HTTPRoute is enabled." }}
+  {{- end }}
+  parentRefs:
+  {{- range .Values.httproute.parentRefs }}
+  - group: {{ .group | default "gateway.networking.k8s.io" }}
+    kind: {{ .kind | default "Gateway" }}
+    name: {{ .name }}
+    {{- with .namespace }}
+    namespace: {{ . }}
+    {{- end }}
+    {{- with .sectionName }}
+    sectionName: {{ . }}
+    {{- end }}
+  {{- end }}
+  {{- with .Values.httproute.hostnames }}
+  hostnames:
+  {{- range . }}
+  - {{ . | quote }}
+  {{- end }}
+  {{- end }}
+  rules:
+  {{- if .Values.httproute.rules }}
+  {{- range .Values.httproute.rules }}
+  - {{- toYaml (omit . "backendRefs") | nindent 4 }}
+    backendRefs:
+    - group: ''
+      kind: Service
+      name: {{ $fullName }}
+      port: {{ $httpPort }}
+  {{- end }}
+  {{- else }}
+  - matches:
+    - path:
+        type: {{ .Values.httproute.pathType | default "PathPrefix" }}
+        value: {{ .Values.httproute.path | default "/" }}
+    backendRefs:
+    - group: ''
+      kind: Service
+      name: {{ $fullName }}
+      port: {{ $httpPort }}
+  {{- end }}
+{{- end }}

--- a/charts/zot/unittests/httproute_test.yaml
+++ b/charts/zot/unittests/httproute_test.yaml
@@ -1,0 +1,230 @@
+suite: test httproute
+templates:
+  - httproute.yaml
+tests:
+  - it: should be empty if httproute is not enabled
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should have apiVersion gateway.networking.k8s.io/v1
+    set:
+      httproute.enabled: true
+      httproute.parentRefs:
+        - name: test-gateway
+      httproute.hostnames:
+        - zot.example.com
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: HTTPRoute
+      - isAPIVersion:
+          of: gateway.networking.k8s.io/v1
+  - it: should have correct parentRefs with defaults
+    set:
+      httproute.enabled: true
+      httproute.parentRefs:
+        - name: test-gateway
+      httproute.hostnames:
+        - zot.example.com
+    asserts:
+      - equal:
+          path: spec.parentRefs[0].name
+          value: test-gateway
+      - equal:
+          path: spec.parentRefs[0].group
+          value: gateway.networking.k8s.io
+      - equal:
+          path: spec.parentRefs[0].kind
+          value: Gateway
+  - it: should have correct parentRefs with custom namespace and sectionName
+    set:
+      httproute.enabled: true
+      httproute.parentRefs:
+        - name: test-gateway
+          namespace: gateway-system
+          sectionName: https
+      httproute.hostnames:
+        - zot.example.com
+    asserts:
+      - equal:
+          path: spec.parentRefs[0].name
+          value: test-gateway
+      - equal:
+          path: spec.parentRefs[0].namespace
+          value: gateway-system
+      - equal:
+          path: spec.parentRefs[0].sectionName
+          value: https
+  - it: should have correct hostnames
+    set:
+      httproute.enabled: true
+      httproute.parentRefs:
+        - name: test-gateway
+      httproute.hostnames:
+        - zot.example.com
+        - registry.example.com
+    asserts:
+      - equal:
+          path: spec.hostnames[0]
+          value: zot.example.com
+      - equal:
+          path: spec.hostnames[1]
+          value: registry.example.com
+  - it: should have default path rule when rules are not specified
+    set:
+      httproute.enabled: true
+      httproute.parentRefs:
+        - name: test-gateway
+      httproute.hostnames:
+        - zot.example.com
+    asserts:
+      - equal:
+          path: spec.rules[0].matches[0].path.type
+          value: PathPrefix
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /
+      - equal:
+          path: spec.rules[0].backendRefs[0].name
+          value: RELEASE-NAME-zot
+      - equal:
+          path: spec.rules[0].backendRefs[0].port
+          value: 5000
+  - it: should use custom pathType and path when specified
+    set:
+      httproute.enabled: true
+      httproute.parentRefs:
+        - name: test-gateway
+      httproute.hostnames:
+        - zot.example.com
+      httproute.pathType: Exact
+      httproute.path: /v2/
+    asserts:
+      - equal:
+          path: spec.rules[0].matches[0].path.type
+          value: Exact
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /v2/
+  - it: should use custom rules when specified
+    set:
+      httproute.enabled: true
+      httproute.parentRefs:
+        - name: test-gateway
+      httproute.hostnames:
+        - zot.example.com
+      httproute.rules:
+        - matches:
+          - path:
+              type: PathPrefix
+              value: /v2/
+    asserts:
+      - equal:
+          path: spec.rules[0].matches[0].path.type
+          value: PathPrefix
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /v2/
+  - it: should include labels and annotations when specified
+    set:
+      httproute.enabled: true
+      httproute.parentRefs:
+        - name: test-gateway
+      httproute.labels:
+        custom-label: label-value
+      httproute.annotations:
+        custom-annotation: annotation-value
+    asserts:
+      - equal:
+          path: metadata.labels.custom-label
+          value: label-value
+      - equal:
+          path: metadata.annotations.custom-annotation
+          value: annotation-value
+  - it: should include rule filters when specified
+    set:
+      httproute.enabled: true
+      httproute.parentRefs:
+        - name: test-gateway
+      httproute.rules:
+        - matches:
+          - path:
+              type: PathPrefix
+              value: /v2/
+          filters:
+          - type: RequestHeaderModifier
+            requestHeaderModifier:
+              add:
+              - name: X-Custom-Header
+                value: custom-value
+    asserts:
+      - equal:
+          path: spec.rules[0].filters[0].type
+          value: RequestHeaderModifier
+      - equal:
+          path: spec.rules[0].filters[0].requestHeaderModifier.add[0].name
+          value: X-Custom-Header
+      - equal:
+          path: spec.rules[0].filters[0].requestHeaderModifier.add[0].value
+          value: custom-value
+  - it: should support multiple custom rules
+    set:
+      httproute.enabled: true
+      httproute.parentRefs:
+        - name: test-gateway
+      httproute.hostnames:
+        - zot.example.com
+      httproute.rules:
+        - matches:
+          - path:
+              type: PathPrefix
+              value: /v2/
+        - matches:
+          - path:
+              type: Exact
+              value: /healthz
+    asserts:
+      - equal:
+          path: spec.rules[0].matches[0].path.type
+          value: PathPrefix
+      - equal:
+          path: spec.rules[0].matches[0].path.value
+          value: /v2/
+      - equal:
+          path: spec.rules[1].matches[0].path.type
+          value: Exact
+      - equal:
+          path: spec.rules[1].matches[0].path.value
+          value: /healthz
+  - it: should support rule filters without matches
+    set:
+      httproute.enabled: true
+      httproute.parentRefs:
+        - name: test-gateway
+      httproute.hostnames:
+        - zot.example.com
+      httproute.rules:
+        - filters:
+          - type: RequestHeaderModifier
+            requestHeaderModifier:
+              add:
+              - name: X-Filter-Only
+                value: filter-only-value
+    asserts:
+      - equal:
+          path: spec.rules[0].filters[0].type
+          value: RequestHeaderModifier
+      - equal:
+          path: spec.rules[0].filters[0].requestHeaderModifier.add[0].name
+          value: X-Filter-Only
+      - equal:
+          path: spec.rules[0].filters[0].requestHeaderModifier.add[0].value
+          value: filter-only-value
+  - it: should fail if parentRefs is empty
+    set:
+      httproute.enabled: true
+      httproute.parentRefs: []
+    asserts:
+      - failedTemplate:
+          errorMessage: "At least one parentRef is required when HTTPRoute is enabled."

--- a/charts/zot/values.yaml
+++ b/charts/zot/values.yaml
@@ -59,6 +59,43 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+# -- HTTPRoute configuration for Gateway API (alternative to Ingress). Only enable this if you have Gateway API CRDs installed and a Gateway controller.
+httproute:
+  # -- Enable HTTPRoute resource creation instead of (or in addition to) Ingress.
+  enabled: false
+  # -- Annotations to add to the HTTPRoute resource.
+  annotations: {}
+  # -- Labels to add to the HTTPRoute resource.
+  labels: {}
+  # -- Gateway references that the HTTPRoute attaches to. At least one parentRef is required when HTTPRoute is enabled.
+  parentRefs: []
+  # Example parentRefs configuration:
+  # - name: my-gateway
+  #   namespace: gateway-system
+  #   sectionName: https  # Optional: specific listener on the gateway
+  # -- Hostnames to match for this HTTPRoute.
+  hostnames: []
+  # Example:
+  # - "zot.example.com"
+  # - "registry.example.com"
+  # -- Path matching type (PathPrefix, Exact, or RegularExpression).
+  pathType: PathPrefix
+  # -- Path to match when custom rules are not specified.
+  path: /
+  # -- Advanced routing rules (optional). If not specified, a default rule matching the path will be created.
+  # Note: Any backendRefs in custom rules will be ignored and the zot service will always be used.
+  rules: []
+  # Example rules configuration:
+  # - matches:
+  #   - path:
+  #       type: PathPrefix
+  #       value: /v2/
+  #   filters:
+  #   - type: RequestHeaderModifier
+  #     requestHeaderModifier:
+  #       add:
+  #       - name: X-Custom-Header
+  #         value: custom-value
 # By default, Kubernetes HTTP probes use HTTP 'scheme'. So if TLS is enabled
 # in configuration, to prevent failures, the scheme must be set to 'HTTPS'.
 httpGet:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

feature
<!--
Add one of the following:
bug
cleanup
documentation
feature
-->

**Which issue does this PR fix**:


**What does this PR do / Why do we need it**:
Add HTTPRoute support for Gateway API. Gateway API is the successor to Ingress API with improved design and capabilities.

**If an issue # is not available please add repro steps and logs showing the issue**:


**Testing done on this change**:

Test 1: Render with HTTPRoute enabled with minimal config
```
helm template zot charts/zot \
  --set httproute.enabled=true \
  --set 'httproute.parentRefs[0].name=my-gateway' \
  --set 'httproute.hostnames[0]=zot.example.com' \
  --show-only templates/httproute.yaml
```
Result
```
---
# Source: zot/templates/httproute.yaml
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: zot
  namespace: default
  labels:
    helm.sh/chart: zot-0.1.98
    app.kubernetes.io/name: zot
    app.kubernetes.io/instance: zot
    app.kubernetes.io/version: "v2.1.14"
    app.kubernetes.io/managed-by: Helm
spec:
  parentRefs:
  - group: gateway.networking.k8s.io
    kind: Gateway
    name: my-gateway
  hostnames:
  - "zot.example.com"
  rules:
  - matches:
    - path:
        type: PathPrefix
        value: /
    backendRefs:
    - group: ''
      kind: Service
      name: zot
      port: 5000
```
Test 2: Render with HTTPRoute enabled with custom rules
```
helm template zot charts/zot \
  --set httproute.enabled=true \
  --set 'httproute.parentRefs[0].name=my-gateway' \
  --set 'httproute.hostnames[0]=zot.example.com' \
  --set 'httproute.rules[0].matches[0].path.type=PathPrefix' \
  --set 'httproute.rules[0].matches[0].path.value=/v2/' \
  --show-only templates/httproute.yaml
```
Result
```
---
# Source: zot/templates/httproute.yaml
apiVersion: gateway.networking.k8s.io/v1
kind: HTTPRoute
metadata:
  name: zot
  namespace: default
  labels:
    helm.sh/chart: zot-0.1.98
    app.kubernetes.io/name: zot
    app.kubernetes.io/instance: zot
    app.kubernetes.io/version: "v2.1.14"
    app.kubernetes.io/managed-by: Helm
spec:
  parentRefs:
  - group: gateway.networking.k8s.io
    kind: Gateway
    name: my-gateway
  hostnames:
  - "zot.example.com"
  rules:
  - matches:
        - path:
            type: PathPrefix
            value: /v2/
    backendRefs:
    - group: ''
      kind: Service
      name: zot
      port: 5000
```
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->

**Automation added to e2e**:
<!-- 
Test case added to lib/integration.sh 
If no, create an issue with enhancement/testing label
-->

**Will this break upgrades or downgrades?**
No

**Does this PR introduce any user-facing change?**:
This implementation adds HTTPRoute as an alternative to Ingress, not a replacement.
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note
Create a new HTTPRoute template that follows Gateway API v1 standards with:
- Conditional rendering based on httproute.enabled flag
- Support for parentRefs (gateway references)
- Support for custom hostnames
- Support for custom rules and path matching
- Support for custom labels and annotations
- Backend reference to the zot service
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
