### PR TITLE
ci: publish charts to GHCR and split CI from release

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -1,3 +1,4 @@
+name: chart-releaser
 on:
   push:
     branches:
@@ -5,19 +6,21 @@ on:
   pull_request:
     branches:
       - main
-name: chart-releaser
+
+permissions:
+  contents: read
+
 jobs:
-  helm-chart-release:
-    # If this workflow pushed an auto-bump commit, skip the rerun to avoid duplicate work.
-    if: ${{ github.event_name != 'push' || !contains(github.event.head_commit.message, '[skip ci]') }}
+  ci:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
       - name: Checkout
         uses: actions/checkout@v5
         with:
           fetch-depth: 0
-          # Use HELM_PUSH_TOKEN when available (push to main), otherwise fall back to GITHUB_TOKEN.
-          token: ${{ (github.event_name == 'push' && github.ref_name == 'main' && secrets.HELM_PUSH_TOKEN) || github.token }}
+          token: ${{ github.token }}
 
       - name: Configure Git
         run: |
@@ -96,9 +99,64 @@ jobs:
         run: |
           ct install --upgrade --target-branch ${{ env.TARGET_BRANCH }} --debug
 
-      - if: github.event_name == 'push' && github.ref_name == 'main'
-        name: Auto-bump chart versions and regenerate docs
+  release:
+    needs: ci
+    if: ${{ github.event_name == 'push' && github.ref_name == 'main' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      packages: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+          token: ${{ github.token }}
+
+      - name: Configure Git
         run: |
+          git config user.name 'github-actions'
+          git config user.email 'github-actions@users.noreply.github.com'
+
+      - name: Install Helm
+        uses: azure/setup-helm@v4.3.1
+        with:
+          version: v3.19.4
+
+      - uses: actions/setup-python@v6
+        with:
+          python-version: '3.9'
+          check-latest: true
+
+      - name: Install chart-testing
+        uses: helm/chart-testing-action@v2.7.0
+
+      - name: Install helm-docs
+        uses: losisin/helm-docs-github-action@v1.6.2
+        with:
+          git-push: false
+          chart-search-root: charts
+
+      - name: Set target branch on push
+        run: |
+          echo "TARGET_BRANCH=${{ github.ref_name }}" >> $GITHUB_ENV
+          echo "SINCE=${{ github.event.before }}" >> $GITHUB_ENV
+
+      - name: Run chart-testing list-changed
+        id: list-changed
+        run: |
+          changed=$(ct list-changed --target-branch ${{ env.TARGET_BRANCH }} --since ${{ env.SINCE }})
+          if [[ -n "$changed" ]]; then
+            echo "changed=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "changed=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Auto-bump chart versions and regenerate docs
+        id: auto-bump
+        run: |
+          echo "chart_changed=false" >> "$GITHUB_OUTPUT"
+
           echo "Running chart tracker (since=${{ github.event.before }})..."
 
           rc=0
@@ -112,8 +170,10 @@ jobs:
             if git diff --staged --quiet; then
               echo "No changes to commit"
             else
-              git commit -m "chore: auto-bump chart versions and update docs [skip ci] [skip pr]"
+              git commit -m "chore: auto-bump chart versions and update docs"
               git push origin ${{ github.ref_name }}
+
+              echo "chart_changed=true" >> "$GITHUB_OUTPUT"
             fi
           elif [ "$rc" -eq 0 ]; then
             echo "No charts need version bumps"
@@ -124,8 +184,7 @@ jobs:
 
           python3 ./scripts/chart_tracker.py cleanup
 
-      - if: github.event_name == 'push' && github.ref_name == 'main'
-        name: Prepare GPG key for signing
+      - name: Prepare GPG key for signing
         env:
           GPG_PRIVATE_KEY: "${{ secrets.GPG_PRIVATE_KEY }}"
           GPG_PASSPHRASE: "${{ secrets.GPG_PASSPHRASE }}"
@@ -158,8 +217,7 @@ jobs:
           gpg --list-secret-keys --keyid-format LONG
           ls -lh keyring.gpg
 
-      - if: github.event_name == 'push' && github.ref_name == 'main'
-        name: Run chart-releaser
+      - name: Run chart-releaser
         uses: helm/chart-releaser-action@v1.7.0
         with:
           charts_dir: charts
@@ -170,3 +228,12 @@ jobs:
           CR_KEYRING: keyring.gpg
           CR_PASSPHRASE_FILE: passphrase-file.txt
           CR_SIGN: true
+
+      - if: ${{ steps.list-changed.outputs.changed == 'true' || steps.auto-bump.outputs.chart_changed == 'true' }}
+        name: Push charts to GHCR
+        env:
+          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          HELM_SIGN_KEY: "${{ secrets.GPG_KEY_NAME }}"
+          HELM_KEYRING: keyring.gpg
+          HELM_PASSPHRASE_FILE: passphrase-file.txt
+        run: ./scripts/push-charts-ghcr.sh

--- a/PROVENANCE.md
+++ b/PROVENANCE.md
@@ -65,6 +65,23 @@ gpg --import signing-key.pub
 
 > ⚠️ **Warning**: Always verify the fingerprint matches `6559 87EE 2D5C 291F CDFA  6592 606D B108 4F6D 3EF0` before trusting the key.
 
+## OCI charts (e.g. GHCR)
+
+Charts pushed with `helm push` can include the same GPG provenance (`.prov`) as a **second layer** on the OCI manifest when the `.prov` file sits next to the `.tgz` at push time ([Helm OCI registries](https://helm.sh/docs/topics/registries/)).
+
+After importing the project public key using the same steps as in the **Complete Example** section above, pull with `--prov` and verify locally:
+
+```bash
+# Import key (once) — same steps as in "Complete Example"
+
+helm pull oci://ghcr.io/project-zot/helm-charts/zot --version <version> --prov
+helm verify zot-<version>.tgz
+
+helm install my-zot oci://ghcr.io/project-zot/helm-charts/zot --version <version> --verify
+```
+
+If `--prov` does not fetch a `.prov` file, that chart tag may have been published without signing or your Helm client/registry combination did not expose the provenance layer.
+
 ## Troubleshooting
 
 ### "WARNING: Verification not found"

--- a/README.md
+++ b/README.md
@@ -1,7 +1,39 @@
 # Helm Charts
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fproject-zot%2Fhelm-charts.svg?type=shield)](https://app.fossa.com/projects/git%2Bgithub.com%2Fproject-zot%2Fhelm-charts?ref=badge_shield)
 
+## Installation
 
+### Using OCI registry (ghcr.io)
+
+Charts are published to the GitHub Container Registry as OCI artifacts. You can install directly without adding a Helm repository:
+
+```bash
+# Install the chart
+helm install zot oci://ghcr.io/project-zot/helm-charts/zot --version <version>
+
+# Inspect default values before installing
+helm show values oci://ghcr.io/project-zot/helm-charts/zot --version <version>
+
+# Upgrade an existing release
+helm upgrade zot oci://ghcr.io/project-zot/helm-charts/zot --version <version>
+```
+
+Replace `<version>` with the desired chart version (e.g. `0.1.110`). You can find the list of available versions on the [ghcr.io package page](https://github.com/project-zot/helm-charts/pkgs/container/helm-charts%2Fzot).
+
+### Using the Helm repository (Artifact Hub)
+
+```bash
+# Add the zot Helm repository
+helm repo add project-zot https://zotregistry.dev/helm-charts
+
+# Update repositories
+helm repo update
+
+# Install the chart
+helm install zot project-zot/zot
+```
+
+Find the chart on [Artifact Hub](https://artifacthub.io/packages/helm/project-zot/zot).
 
 ## License
 [![FOSSA Status](https://app.fossa.com/api/projects/git%2Bgithub.com%2Fproject-zot%2Fhelm-charts.svg?type=large)](https://app.fossa.com/projects/git%2Bgithub.com%2Fproject-zot%2Fhelm-charts?ref=badge_large)

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -91,7 +91,7 @@ The script is automatically used by the CI/CD workflow to:
 5. Script deduplicates and tracks unique charts that need version bumps
 6. Script calls `bump_patch_version()` function directly for each chart (handled internally)
 7. Generates helm-docs for all charts
-8. Commits changes with message: `chore: auto-bump chart versions and update docs [skip pr]`
+8. Commits changes with message: `chore: auto-bump chart versions and update docs`
 
 ### Smart Detection
 

--- a/scripts/push-charts-ghcr.sh
+++ b/scripts/push-charts-ghcr.sh
@@ -1,0 +1,100 @@
+#!/usr/bin/env bash
+# Package every top-level chart under charts/<name>/ and push .tgz artifacts to GHCR (OCI).
+# Skips vendored dependency charts under charts/<name>/charts/<dep>/.
+#
+# Environment:
+#   GITHUB_TOKEN     — required; used for helm registry login
+#   GITHUB_ACTOR     — username for ghcr.io login (set automatically in GitHub Actions)
+#   CHARTS_ROOT      — default: charts
+#   REGISTRY_HOST    — default: ghcr.io
+#   OCI_REPOSITORY — default: oci://ghcr.io/project-zot/helm-charts
+#
+# Optional GPG signing (Helm provenance .prov — uploaded with helm push when present):
+#   HELM_SIGN_KEY          — secret key name / UID (matches chart-releaser CR_KEY / gpg uid)
+#   HELM_KEYRING           — default: keyring.gpg — must contain *private* keys.
+#                            Binary OpenPGP (same as: gpg --export-secret-keys without -a).
+#                            ASCII-armored (.asc / many .pgp exports): script runs gpg --dearmor automatically.
+#   HELM_PASSPHRASE_FILE   — default: passphrase-file.txt (passphrase for that private key)
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+CHARTS_ROOT="${CHARTS_ROOT:-charts}"
+REGISTRY_HOST="${REGISTRY_HOST:-ghcr.io}"
+OCI_REPOSITORY="${OCI_REPOSITORY:-oci://ghcr.io/project-zot/helm-charts}"
+HELM_KEYRING="${HELM_KEYRING:-keyring.gpg}"
+HELM_PASSPHRASE_FILE="${HELM_PASSPHRASE_FILE:-passphrase-file.txt}"
+
+_helm_ring_bin=""
+cleanup_push_charts() {
+  rm -rf "${WORKDIR:-}"
+  [[ -n "${_helm_ring_bin:-}" && -f "${_helm_ring_bin}" ]] && rm -f "${_helm_ring_bin}"
+}
+
+if [[ -z "${GITHUB_TOKEN:-}" ]]; then
+  echo "GITHUB_TOKEN is required" >&2
+  exit 1
+fi
+
+if [[ -z "${GITHUB_ACTOR:-}" ]]; then
+  echo "GITHUB_ACTOR is required (use your ghcr.io username locally)" >&2
+  exit 1
+fi
+
+echo "$GITHUB_TOKEN" | helm registry login "$REGISTRY_HOST" --username "$GITHUB_ACTOR" --password-stdin
+
+WORKDIR="$(mktemp -d)"
+trap cleanup_push_charts EXIT
+mkdir -p "$WORKDIR/packaged"
+
+mapfile -t chart_yamls < <(
+  find "$CHARTS_ROOT" -maxdepth 3 -path "${CHARTS_ROOT}/*/charts/*" -prune -o -path "${CHARTS_ROOT}/*/Chart.yaml" -print | sort
+)
+
+if [[ ${#chart_yamls[@]} -eq 0 ]]; then
+  echo "No Chart.yaml files found under ${CHARTS_ROOT}/" >&2
+  exit 1
+fi
+
+sign_opts=()
+if [[ -n "${HELM_SIGN_KEY:-}" && -f "$HELM_KEYRING" && -f "$HELM_PASSPHRASE_FILE" ]]; then
+  keyring_for_helm="$HELM_KEYRING"
+  # Helm uses Go openpgp and expects binary packets; ASCII armor yields: openpgp: invalid data: tag byte does not have MSB set
+  if grep -q '^-----BEGIN PGP' "$HELM_KEYRING" 2>/dev/null; then
+    _helm_ring_bin="$(mktemp)"
+    gpg --batch --yes --dearmor --output "$_helm_ring_bin" "$HELM_KEYRING"
+    keyring_for_helm="$_helm_ring_bin"
+    echo "HELM_KEYRING is ASCII-armored; using dearmored copy for Helm"
+  fi
+
+  echo "GPG signing enabled for packaged charts (key=$HELM_SIGN_KEY)"
+  sign_opts=(--sign --key "$HELM_SIGN_KEY" --keyring "$keyring_for_helm" --passphrase-file "$HELM_PASSPHRASE_FILE")
+else
+  echo "GPG signing skipped (set HELM_SIGN_KEY and ensure $HELM_KEYRING and $HELM_PASSPHRASE_FILE exist)"
+fi
+
+for chart_yaml in "${chart_yamls[@]}"; do
+  chart_dir="$(dirname "$chart_yaml")"
+  echo "Packaging: $chart_dir"
+  helm package "$chart_dir" --destination "$WORKDIR/packaged" "${sign_opts[@]}"
+done
+
+shopt -s nullglob
+pkgs=("$WORKDIR"/packaged/*.tgz)
+shopt -u nullglob
+
+if [[ ${#pkgs[@]} -eq 0 ]]; then
+  echo "No chart packages produced" >&2
+  ls -la "$WORKDIR/packaged" >&2 || true
+  exit 1
+fi
+
+mapfile -t pkgs_sorted < <(printf '%s\n' "${pkgs[@]}" | sort)
+
+for pkg in "${pkgs_sorted[@]}"; do
+  echo "Pushing: $pkg"
+  helm push "$pkg" "$OCI_REPOSITORY"
+done

--- a/scripts/test_chart_tracker.py
+++ b/scripts/test_chart_tracker.py
@@ -496,7 +496,6 @@ index 1234567..abcdefg 100644
         """Test process_all_changes when all charts already have version bumps"""
         # Mock chart changes
         mock_ct.return_value = ["charts/test1", "charts/test2"]
-        mock_helm_docs.return_value = []
 
         # Mock that all charts already have version bumps
         mock_check_bumps.return_value = ["charts/test1", "charts/test2"]


### PR DESCRIPTION
- Run lint/tests in a dedicated CI job; run chart-releaser + GHCR only on main after CI passes
- Checkout/push using GITHUB_TOKEN only (drop HELM_PUSH_TOKEN)
- Add scripts/push-charts-ghcr.sh to package and push all top-level charts under charts/
- Add provenance for the new package

Push Helm chart to ghcr.io as OCI artifact and document installation

Agent-Logs-Url: https://github.com/project-zot/helm-charts/sessions/1a3faab9-43c2-4f4f-b95d-dd1c238cff2b

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
