### PR TITLE
fix(zot): always emit StatefulSet serviceName for strict validators

### DIFF
--- a/charts/zot/templates/statefulset.yaml
+++ b/charts/zot/templates/statefulset.yaml
@@ -12,9 +12,7 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  {{- if and .Values.serviceHeadless .Values.serviceHeadless.enabled }}
-  serviceName: {{ include "zot.fullname" . }}-headless
-  {{- end }}
+  serviceName: {{ include "zot.fullname" . }}{{ if and .Values.serviceHeadless .Values.serviceHeadless.enabled }}-headless{{ end }}
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:

--- a/charts/zot/unittests/statefulset_test.yaml
+++ b/charts/zot/unittests/statefulset_test.yaml
@@ -154,15 +154,23 @@ tests:
             mountPath: /var/lib/registry
             name: my-release-pvc
 
+  - it: should always set serviceName by default (not headless)
+    set:
+      persistence: true
+    asserts:
+      - equal:
+          path: spec.serviceName
+          value: my-release-zot
+
   - it: should have an headless service when enabled
     set:
       persistence: true
       serviceHeadless:
         enabled: true
     asserts:
-      - matchRegex:
+      - equal:
           path: spec.serviceName
-          pattern: .*-headless$
+          value: my-release-zot-headless
 
   - it: should not have initContainers when not set
     set:


### PR DESCRIPTION
**What type of PR is this?**

bug

**Which issue does this PR fix**:

Closes #124

**What does this PR do / Why do we need it**:

The StatefulSet rendered by `charts/zot` was missing the `spec.serviceName`
field whenever `serviceHeadless.enabled` was `false` (the chart default).
Per the Kubernetes OpenAPI schema, `serviceName` is a required field on
`apps/v1 StatefulSet`. The API server defaults it server-side, so live
clusters accept the manifest, but strict client-side validators
(`kubeconform --strict`, `kubectl-validate`, GitOps render-validation
pipelines) reject it.

This change always emits `serviceName`, falling back to the standard
fullname when the headless service is disabled, and using the
`-headless` suffix when it is enabled.

```yaml
serviceName: {{ include "zot.fullname" . }}{{ if and .Values.serviceHeadless .Values.serviceHeadless.enabled }}-headless{{ end }}
```

**If an issue # is not available please add repro steps and logs showing the issue**:

Repro from the issue:

```bash
helm pull zot --repo https://zotregistry.dev/helm-charts --version 0.1.112 \
  --untar --untardir /tmp/zot
helm template zot /tmp/zot/zot --set persistence=true | kubeconform -strict
# StatefulSet zot is invalid: at '/spec': missing property 'serviceName'
```

**Testing done on this change**:

- `helm lint charts/zot` — passes.
- `helm template zot charts/zot --set persistence=true | kubeconform -strict -kubernetes-version 1.31.0 -ignore-missing-schemas -` — clean (was failing before).
- `helm template zot charts/zot --set persistence=true | grep serviceName:` -> `serviceName: zot` (default).
- `helm template zot charts/zot --set persistence=true --set serviceHeadless.enabled=true | grep serviceName:` -> `serviceName: zot-headless` (preserves prior headless behavior).
- `helm unittest --strict --file 'unittests/*.yaml' charts/zot` — 52 tests pass (was 51), including two assertions added in `charts/zot/unittests/statefulset_test.yaml`:
  - default render asserts `spec.serviceName == my-release-zot`
  - `serviceHeadless.enabled: true` asserts `spec.serviceName == my-release-zot-headless` (tightened from a regex match to an exact equality).

**Automation added to e2e**:

Two new helm-unittest assertions cover the bug and the headless variant
(see `charts/zot/unittests/statefulset_test.yaml`). No e2e
`tests/ci/*` change is needed because the live API server does not
reject the prior manifest; the regression is purely a client-side
schema-validation issue, which is what the unit tests now guard.

**Will this break upgrades or downgrades?**

No. The emitted `serviceName` matches the value the Kubernetes API
server already defaults the field to server-side, so existing
StatefulSets keep the same identity. Headless-service users continue to
get `<fullname>-headless` exactly as before.

**Does this PR introduce any user-facing change?**:

```release-note
Always emit `spec.serviceName` on the rendered StatefulSet so that
strict client-side schema validators (kubeconform, kubectl-validate,
GitOps render-validation pipelines) accept the manifest. Behavior in
live clusters is unchanged.
```

---

Context: surfaced while wiring kubeconform into a GitOps
render-validation pipeline that gates ArgoCD `Application` manifests on
schema-clean rendered output.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.