### PR TITLE
fix(zot): gate StatefulSet serviceName on statefulSet.strictServiceName

### DIFF
--- a/charts/zot/README.md
+++ b/charts/zot/README.md
@@ -85,6 +85,8 @@ A zot registry helm chart for Kubernetes
 | serviceHeadless.annotations | object | `{}` |  |
 | serviceHeadless.enabled | bool | `false` |  |
 | serviceHeadless.port | int | `5000` |  |
+| statefulSet | object | `{"strictServiceName":true}` | StatefulSet options; only applies when persistence is enabled. |
+| statefulSet.strictServiceName | bool | `true` | If true, always render StatefulSet `spec.serviceName` (recommended for strict schema validators). If false, omit `serviceName` unless headless is enabled; use when an upgrade fails on immutable `serviceName`. With false and headless off, strict OpenAPI-style validators (for example kubeconform --strict) may reject the manifest; keep true for schema-gated GitOps or CI. |
 | startupProbe.failureThreshold | int | `3` |  |
 | startupProbe.initialDelaySeconds | int | `5` |  |
 | startupProbe.periodSeconds | int | `10` |  |

--- a/charts/zot/templates/statefulset.yaml
+++ b/charts/zot/templates/statefulset.yaml
@@ -12,7 +12,14 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  serviceName: {{ include "zot.fullname" . }}{{ if and .Values.serviceHeadless .Values.serviceHeadless.enabled }}-headless{{ end }}
+{{- $headless := and .Values.serviceHeadless .Values.serviceHeadless.enabled }}
+{{- $strictServiceName := true -}}
+{{- if and .Values.statefulSet (hasKey .Values.statefulSet "strictServiceName") -}}
+{{- $strictServiceName = .Values.statefulSet.strictServiceName -}}
+{{- end -}}
+{{- if or $strictServiceName $headless }}
+  serviceName: {{ include "zot.fullname" . }}{{ if $headless }}-headless{{ end }}
+{{- end }}
   replicas: {{ .Values.replicaCount }}
   selector:
     matchLabels:

--- a/charts/zot/unittests/statefulset_test.yaml
+++ b/charts/zot/unittests/statefulset_test.yaml
@@ -162,6 +162,28 @@ tests:
           path: spec.serviceName
           value: my-release-zot
 
+  # Legacy template shape: omits spec.serviceName (may fail strict schema validators; see values.statefulSet.strictServiceName).
+  - it: should omit serviceName when strictServiceName is false and headless is disabled
+    set:
+      persistence: true
+      statefulSet:
+        strictServiceName: false
+    asserts:
+      - isNull:
+          path: spec.serviceName
+
+  - it: should set headless serviceName when strictServiceName is false but headless is enabled
+    set:
+      persistence: true
+      statefulSet:
+        strictServiceName: false
+      serviceHeadless:
+        enabled: true
+    asserts:
+      - equal:
+          path: spec.serviceName
+          value: my-release-zot-headless
+
   - it: should have an headless service when enabled
     set:
       persistence: true

--- a/charts/zot/values.yaml
+++ b/charts/zot/values.yaml
@@ -24,6 +24,13 @@ serviceHeadless:
   port: 5000
   # Annotations to add to the headless service
   annotations: {}
+# -- StatefulSet options; only applies when persistence is enabled.
+statefulSet:
+  # -- If true, always render StatefulSet `spec.serviceName` (recommended for strict schema validators).
+  # If false, omit `serviceName` unless headless is enabled; use when an upgrade fails on immutable `serviceName`.
+  # With false and headless off, the chart matches older template output but the rendered StatefulSet may not pass
+  # strict OpenAPI checks (for example kubeconform --strict); keep true when GitOps or CI gates on schema-clean YAML.
+  strictServiceName: true
 service:
   type: NodePort
   port: 5000


### PR DESCRIPTION
Default true preserves strict-schema-friendly manifests; false restores omit-when-not-headless behavior for difficult upgrades. README + tests.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
