### PR TITLE
feat(helm): add hostAliases support for main pod

### DIFF
--- a/charts/zot/templates/deployment.yaml
+++ b/charts/zot/templates/deployment.yaml
@@ -166,4 +166,8 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       dnsPolicy: {{ .Values.dnsPolicy }}
+      {{- with .Values.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{ end }}

--- a/charts/zot/templates/statefulset.yaml
+++ b/charts/zot/templates/statefulset.yaml
@@ -190,5 +190,9 @@ spec:
         {{- toYaml . | nindent 8 }}
       {{- end }}
       dnsPolicy: {{ .Values.dnsPolicy }}
+      {{- with .Values.hostAliases }}
+      hostAliases:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
 {{- end -}}
 

--- a/charts/zot/unittests/deployment_test.yaml
+++ b/charts/zot/unittests/deployment_test.yaml
@@ -41,3 +41,25 @@ tests:
       - equal:
           path: spec.template.spec.initContainers[0].image
           value: busybox
+
+  - it: should not have hostAliases when not set
+    set:
+      persistence: false
+    asserts:
+      - isNull:
+          path: spec.template.spec.hostAliases
+
+  - it: should render hostAliases when set
+    set:
+      persistence: false
+      hostAliases:
+        - ip: "1.2.3.4"
+          hostnames:
+            - "foo.local"
+    asserts:
+      - equal:
+          path: spec.template.spec.hostAliases[0].ip
+          value: "1.2.3.4"
+      - equal:
+          path: spec.template.spec.hostAliases[0].hostnames[0]
+          value: foo.local

--- a/charts/zot/unittests/statefulset_test.yaml
+++ b/charts/zot/unittests/statefulset_test.yaml
@@ -185,3 +185,25 @@ tests:
       - equal:
           path: spec.template.spec.initContainers[0].image
           value: busybox
+
+  - it: should not have hostAliases when not set
+    set:
+      persistence: true
+    asserts:
+      - isNull:
+          path: spec.template.spec.hostAliases
+
+  - it: should render hostAliases when set
+    set:
+      persistence: true
+      hostAliases:
+        - ip: "1.2.3.4"
+          hostnames:
+            - "foo.local"
+    asserts:
+      - equal:
+          path: spec.template.spec.hostAliases[0].ip
+          value: "1.2.3.4"
+      - equal:
+          path: spec.template.spec.hostAliases[0].hostnames[0]
+          value: foo.local

--- a/charts/zot/values.yaml
+++ b/charts/zot/values.yaml
@@ -298,6 +298,7 @@ deploymentAnnotations: {}
 priorityClassName: ""
 dnsConfig: {}
 dnsPolicy: "ClusterFirst"
+hostAliases: []
 # Metrics configuration
 # NOTE: need enable metric extension in config.json
 metrics:


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**

feature

**Which issue does this PR fix**:

#129

**What does this PR do / Why do we need it**:

Optionally adds `hostAliases` spec to pod, similar to `initContainers`.

**If an issue # is not available please add repro steps and logs showing the issue**:

--

**Testing done on this change**:

Added unit tests.

Manually deployed on test cluster:

```
> kubectl debug -it $(kubectl get pod -l app.kubernetes.io/name=zot -o name) --image=busybox:1.36 -- cat /etc/hosts
Defaulting debug container name to debugger-6m5kn.
# Kubernetes-managed hosts file.
127.0.0.1       localhost
::1     localhost ip6-localhost ip6-loopback
fe00::0 ip6-localnet
fe00::0 ip6-mcastprefix
fe00::1 ip6-allnodes
fe00::2 ip6-allrouters
10.0.0.130      zot-test-5db4657949-6s26b

# Entries added by HostAliases.
1.2.3.4 foo.local
```

**Automation added to e2e**:

None. Unit test coverage should be good enough.

**Will this break upgrades or downgrades?**
No 

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->

```release-note

```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
