### PR TITLE
feat(zot): render nodeSelector, affinity and tolerations through tpl

### DIFF
--- a/charts/zot/README.md
+++ b/charts/zot/README.md
@@ -8,6 +8,7 @@ A zot registry helm chart for Kubernetes
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
+| affinity | object | `{}` | Affinity rules for pod assignment. Also rendered through `tpl` (same escaping / untrusted-input note as nodeSelector above). |
 | configFiles."config.json" | string | `"{\n  \"storage\": { \"rootDirectory\": \"/var/lib/registry\" },\n  \"http\": {\n    \"address\": \"0.0.0.0\",\n    \"port\": \"5000\",\n    \"readTimeout\": \"60s\",\n    \"writeTimeout\": \"60s\"\n  },\n  \"log\": { \"level\": \"debug\" }\n}"` |  |
 | deploymentAnnotations | object | `{}` |  |
 | dnsConfig | object | `{}` |  |
@@ -61,6 +62,7 @@ A zot registry helm chart for Kubernetes
 | mountConfig | bool | `false` |  |
 | mountSecret | bool | `false` |  |
 | namespace | string | `""` |  |
+| nodeSelector | object | `{}` | Node selector for pod assignment. Rendered through `tpl`, so values may contain Helm template expressions (e.g. `{{ .Values.global.pool }}`); a value with no `{{ }}` markers is emitted unchanged. Do not template untrusted input. To output a literal brace, escape it, e.g. `{{ "{{" }}`. |
 | persistence | bool | `false` |  |
 | podAnnotations | object | `{}` |  |
 | podLabels | object | `{}` |  |
@@ -92,6 +94,7 @@ A zot registry helm chart for Kubernetes
 | strategy.type | string | `"RollingUpdate"` |  |
 | test.image.repository | string | `"alpine"` |  |
 | test.image.tag | string | `"3.18"` |  |
+| tolerations | list | `[]` | Tolerations for pod assignment. Also rendered through `tpl` (same escaping / untrusted-input note as nodeSelector above). |
 | topologySpreadConstraints | list | `[]` |  |
 
 ----------------------------------------------

--- a/charts/zot/templates/deployment.yaml
+++ b/charts/zot/templates/deployment.yaml
@@ -151,15 +151,15 @@ spec:
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
       {{- with .Values.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
-        {{- toYaml . | nindent 8 }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
       {{- with .Values.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/zot/templates/statefulset.yaml
+++ b/charts/zot/templates/statefulset.yaml
@@ -175,15 +175,15 @@ spec:
       {{- end }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
       {{- with .Values.affinity }}
       affinity:
-        {{- toYaml . | nindent 8 }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
       {{- with .Values.tolerations }}
       tolerations:
-        {{- toYaml . | nindent 8 }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
       {{- with .Values.topologySpreadConstraints }}
       topologySpreadConstraints:

--- a/charts/zot/unittests/deployment_test.yaml
+++ b/charts/zot/unittests/deployment_test.yaml
@@ -100,3 +100,92 @@ tests:
       - equal:
           path: spec.template.spec.topologySpreadConstraints[1].topologyKey
           value: kubernetes.io/hostname
+
+  - it: should render a static nodeSelector unchanged
+    set:
+      persistence: false
+      nodeSelector:
+        disktype: ssd
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector.disktype
+          value: ssd
+
+  - it: should render static tolerations unchanged
+    set:
+      persistence: false
+      tolerations:
+        - key: dedicated
+          operator: Equal
+          value: zot
+          effect: NoSchedule
+    asserts:
+      - equal:
+          path: spec.template.spec.tolerations[0].key
+          value: dedicated
+      - equal:
+          path: spec.template.spec.tolerations[0].value
+          value: zot
+
+  - it: should render static affinity unchanged
+    set:
+      persistence: false
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: disktype
+                    operator: In
+                    values:
+                      - ssd
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]
+          value: ssd
+
+  - it: should evaluate templates in nodeSelector
+    set:
+      persistence: false
+      global:
+        pool: gpu-pool
+      nodeSelector:
+        service: "{{ .Values.global.pool }}"
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector.service
+          value: gpu-pool
+
+  - it: should evaluate templates in tolerations
+    set:
+      persistence: false
+      global:
+        pool: gpu-pool
+      tolerations:
+        - key: "{{ .Values.global.pool }}"
+          operator: Equal
+          value: dedicated
+          effect: NoSchedule
+    asserts:
+      - equal:
+          path: spec.template.spec.tolerations[0].key
+          value: gpu-pool
+
+  - it: should evaluate templates in affinity
+    set:
+      persistence: false
+      global:
+        pool: gpu-pool
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: pool
+                    operator: In
+                    values:
+                      - "{{ .Values.global.pool }}"
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]
+          value: gpu-pool

--- a/charts/zot/unittests/statefulset_test.yaml
+++ b/charts/zot/unittests/statefulset_test.yaml
@@ -244,3 +244,92 @@ tests:
       - equal:
           path: spec.template.spec.topologySpreadConstraints[1].topologyKey
           value: kubernetes.io/hostname
+
+  - it: should render a static nodeSelector unchanged
+    set:
+      persistence: true
+      nodeSelector:
+        disktype: ssd
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector.disktype
+          value: ssd
+
+  - it: should render static tolerations unchanged
+    set:
+      persistence: true
+      tolerations:
+        - key: dedicated
+          operator: Equal
+          value: zot
+          effect: NoSchedule
+    asserts:
+      - equal:
+          path: spec.template.spec.tolerations[0].key
+          value: dedicated
+      - equal:
+          path: spec.template.spec.tolerations[0].value
+          value: zot
+
+  - it: should render static affinity unchanged
+    set:
+      persistence: true
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: disktype
+                    operator: In
+                    values:
+                      - ssd
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]
+          value: ssd
+
+  - it: should evaluate templates in nodeSelector
+    set:
+      persistence: true
+      global:
+        pool: gpu-pool
+      nodeSelector:
+        service: "{{ .Values.global.pool }}"
+    asserts:
+      - equal:
+          path: spec.template.spec.nodeSelector.service
+          value: gpu-pool
+
+  - it: should evaluate templates in tolerations
+    set:
+      persistence: true
+      global:
+        pool: gpu-pool
+      tolerations:
+        - key: "{{ .Values.global.pool }}"
+          operator: Equal
+          value: dedicated
+          effect: NoSchedule
+    asserts:
+      - equal:
+          path: spec.template.spec.tolerations[0].key
+          value: gpu-pool
+
+  - it: should evaluate templates in affinity
+    set:
+      persistence: true
+      global:
+        pool: gpu-pool
+      affinity:
+        nodeAffinity:
+          requiredDuringSchedulingIgnoredDuringExecution:
+            nodeSelectorTerms:
+              - matchExpressions:
+                  - key: pool
+                    operator: In
+                    values:
+                      - "{{ .Values.global.pool }}"
+    asserts:
+      - equal:
+          path: spec.template.spec.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0]
+          value: gpu-pool

--- a/charts/zot/values.yaml
+++ b/charts/zot/values.yaml
@@ -316,6 +316,17 @@ topologySpreadConstraints: []
 #       matchLabels:
 #         app.kubernetes.io/name: zot
 #         app.kubernetes.io/instance: $CHART_RELEASE
+# -- Node selector for pod assignment. Rendered through `tpl`, so values may
+# contain Helm template expressions (e.g. `{{ .Values.global.pool }}`); a value
+# with no `{{ }}` markers is emitted unchanged. Do not template untrusted input.
+# To output a literal brace, escape it, e.g. `{{ "{{" }}`.
+nodeSelector: {}
+# -- Affinity rules for pod assignment. Also rendered through `tpl` (same
+# escaping / untrusted-input note as nodeSelector above).
+affinity: {}
+# -- Tolerations for pod assignment. Also rendered through `tpl` (same
+# escaping / untrusted-input note as nodeSelector above).
+tolerations: []
 # Metrics configuration
 # NOTE: need enable metric extension in config.json
 metrics:


### PR DESCRIPTION
**What type of PR is this?**

feature

**Which issue does this PR fix**:

N/A — no existing issue. Repro of the gap is below.

**What does this PR do / Why do we need it**:

Renders the pod placement values — `nodeSelector`, `affinity`, and `tolerations` — through `tpl` in both `deployment.yaml` and `statefulset.yaml`, so they may contain Helm template expressions:

```diff
       {{- with .Values.nodeSelector }}
       nodeSelector:
-        {{- toYaml . | nindent 8 }}
+        {{- tpl (toYaml .) $ | nindent 8 }}
       {{- end }}
```

Today these fields are emitted with `toYaml` only, so their values are treated as literal data and can't reference anything else (e.g. a cluster-wide node pool exposed via `global.*` by a parent/umbrella chart). Routing them through `tpl` is the standard chart idiom for this and needs no new dependency or helper. It is fully backward compatible: `tpl` on a value with no `{{ }}` markers returns it unchanged.

**If an issue # is not available please add repro steps and logs showing the issue**:

On current `main`, a templated placement value is emitted verbatim instead of being evaluated:

```console
$ helm template t charts/zot \
    --set persistence=false \
    --set global.pool=gpu-pool \
    --set 'nodeSelector.service={{ .Values.global.pool }}'
...
      nodeSelector:
        service: '{{ .Values.global.pool }}'   # <-- not resolved
```

With this PR the same command renders `service: gpu-pool`.

**Testing done on this change**:

`helm template` (Deployment and StatefulSet paths) + the new helm-unittest suites:

```console
$ helm unittest -f 'unittests/*_test.yaml' charts/zot
Charts:      1 passed, 1 total
Test Suites: 7 passed, 7 total
Tests:       63 passed, 63 total
```

- Static `nodeSelector`/`tolerations` (existing usage) → output byte-identical to current chart.
- Templated `nodeSelector`/`tolerations`/`affinity` referencing `.Values.global.pool` → resolved correctly in both Deployment and StatefulSet.

`helm lint` passes (only the pre-existing "icon is recommended" info).

**Automation added to e2e**:

helm-unittest cases added in `charts/zot/unittests/deployment_test.yaml` and `statefulset_test.yaml` covering static (backward-compat) and templated rendering. The change is pure chart templating, so `lib/integration.sh` e2e isn't applicable.

**Will this break upgrades or downgrades?**

No. Backward compatible — values without template markers render byte-identically, so existing releases are unaffected.

**Does this PR introduce any user-facing change?**:

Yes — placement values may now contain template expressions.

```release-note
zot: nodeSelector, affinity and tolerations are now rendered through `tpl`, so they may contain Helm template expressions. Static values are unaffected.
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
