### PR TITLE
feat: Add Pod Disruption Budget (PDB) support

### DIFF
--- a/charts/zot/templates/pdb.yaml
+++ b/charts/zot/templates/pdb.yaml
@@ -1,0 +1,19 @@
+{{- if .Values.podDisruptionBudget.enabled }}
+apiVersion: policy/v1
+kind: PodDisruptionBudget
+metadata:
+  name: {{ include "zot.fullname" . }}
+  namespace: {{ .Values.namespace | default .Release.Namespace }}
+  labels:
+    {{- include "zot.labels" . | nindent 4 }}
+spec:
+  {{- if not (empty .Values.podDisruptionBudget.minAvailable) }}
+  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- end }}
+  {{- if not (empty .Values.podDisruptionBudget.maxUnavailable) }}
+  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- end }}
+  selector:
+    matchLabels:
+      {{- include "zot.selectorLabels" . | nindent 6 }}
+{{- end }}

--- a/charts/zot/templates/pdb.yaml
+++ b/charts/zot/templates/pdb.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.podDisruptionBudget }}
 {{- if .Values.podDisruptionBudget.enabled }}
 {{- $minAvailable := .Values.podDisruptionBudget.minAvailable }}
 {{- $maxUnavailable := .Values.podDisruptionBudget.maxUnavailable }}
@@ -23,4 +24,5 @@ spec:
   selector:
     matchLabels:
       {{- include "zot.selectorLabels" . | nindent 6 }}
+{{- end }}
 {{- end }}

--- a/charts/zot/templates/pdb.yaml
+++ b/charts/zot/templates/pdb.yaml
@@ -1,4 +1,11 @@
 {{- if .Values.podDisruptionBudget.enabled }}
+{{- $minAvailable := .Values.podDisruptionBudget.minAvailable }}
+{{- $maxUnavailable := .Values.podDisruptionBudget.maxUnavailable }}
+{{- $minSet := not (kindIs "invalid" $minAvailable) }}
+{{- $maxSet := not (kindIs "invalid" $maxUnavailable) }}
+{{- if eq $minSet $maxSet }}
+{{- fail "podDisruptionBudget.enabled is true: set exactly one of podDisruptionBudget.minAvailable or podDisruptionBudget.maxUnavailable" }}
+{{- end }}
 apiVersion: policy/v1
 kind: PodDisruptionBudget
 metadata:
@@ -7,11 +14,11 @@ metadata:
   labels:
     {{- include "zot.labels" . | nindent 4 }}
 spec:
-  {{- if not (empty .Values.podDisruptionBudget.minAvailable) }}
-  minAvailable: {{ .Values.podDisruptionBudget.minAvailable }}
+  {{- if $minSet }}
+  minAvailable: {{ $minAvailable }}
   {{- end }}
-  {{- if not (empty .Values.podDisruptionBudget.maxUnavailable) }}
-  maxUnavailable: {{ .Values.podDisruptionBudget.maxUnavailable }}
+  {{- if $maxSet }}
+  maxUnavailable: {{ $maxUnavailable }}
   {{- end }}
   selector:
     matchLabels:

--- a/charts/zot/unittests/pdb_test.yaml
+++ b/charts/zot/unittests/pdb_test.yaml
@@ -9,6 +9,13 @@ tests:
       - hasDocuments:
           count: 0
 
+  - it: should not fail if podDisruptionBudget is absent
+    set:
+      podDisruptionBudget: null
+    asserts:
+      - hasDocuments:
+          count: 0
+
   - it: should fail if enabled but neither minAvailable nor maxUnavailable is set
     set:
       podDisruptionBudget.enabled: true

--- a/charts/zot/unittests/pdb_test.yaml
+++ b/charts/zot/unittests/pdb_test.yaml
@@ -1,0 +1,49 @@
+suite: test pdb
+templates:
+  - pdb.yaml
+tests:
+  - it: should be empty if podDisruptionBudget is not enabled
+    asserts:
+      - hasDocuments:
+          count: 0
+  - it: should render a PodDisruptionBudget when enabled
+    set:
+      podDisruptionBudget.enabled: true
+    asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodDisruptionBudget
+      - isAPIVersion:
+          of: policy/v1
+      - equal:
+          path: spec.selector.matchLabels
+          value:
+            app.kubernetes.io/name: zot
+            app.kubernetes.io/instance: my-release
+      - isNull:
+          path: spec.minAvailable
+      - isNull:
+          path: spec.maxUnavailable
+  - it: should render minAvailable when set
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 1
+    asserts:
+      - equal:
+          path: spec.minAvailable
+          value: 1
+      - isNull:
+          path: spec.maxUnavailable
+  - it: should render maxUnavailable when set
+    set:
+      podDisruptionBudget:
+        enabled: true
+        maxUnavailable: 1
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 1
+      - isNull:
+          path: spec.minAvailable

--- a/charts/zot/unittests/pdb_test.yaml
+++ b/charts/zot/unittests/pdb_test.yaml
@@ -1,14 +1,36 @@
 suite: test pdb
 templates:
   - pdb.yaml
+release:
+  name: my-release
 tests:
   - it: should be empty if podDisruptionBudget is not enabled
     asserts:
       - hasDocuments:
           count: 0
-  - it: should render a PodDisruptionBudget when enabled
+
+  - it: should fail if enabled but neither minAvailable nor maxUnavailable is set
     set:
       podDisruptionBudget.enabled: true
+    asserts:
+      - failedTemplate:
+          errorMessage: "podDisruptionBudget.enabled is true: set exactly one of podDisruptionBudget.minAvailable or podDisruptionBudget.maxUnavailable"
+
+  - it: should fail if enabled and both minAvailable and maxUnavailable are set
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 1
+        maxUnavailable: 1
+    asserts:
+      - failedTemplate:
+          errorMessage: "podDisruptionBudget.enabled is true: set exactly one of podDisruptionBudget.minAvailable or podDisruptionBudget.maxUnavailable"
+
+  - it: should render minAvailable when set
+    set:
+      podDisruptionBudget:
+        enabled: true
+        minAvailable: 1
     asserts:
       - hasDocuments:
           count: 1
@@ -21,29 +43,43 @@ tests:
           value:
             app.kubernetes.io/name: zot
             app.kubernetes.io/instance: my-release
-      - isNull:
-          path: spec.minAvailable
-      - isNull:
-          path: spec.maxUnavailable
-  - it: should render minAvailable when set
-    set:
-      podDisruptionBudget:
-        enabled: true
-        minAvailable: 1
-    asserts:
       - equal:
           path: spec.minAvailable
           value: 1
       - isNull:
           path: spec.maxUnavailable
+
   - it: should render maxUnavailable when set
     set:
       podDisruptionBudget:
         enabled: true
         maxUnavailable: 1
     asserts:
+      - hasDocuments:
+          count: 1
+      - isKind:
+          of: PodDisruptionBudget
+      - isAPIVersion:
+          of: policy/v1
+      - equal:
+          path: spec.selector.matchLabels
+          value:
+            app.kubernetes.io/name: zot
+            app.kubernetes.io/instance: my-release
       - equal:
           path: spec.maxUnavailable
           value: 1
+      - isNull:
+          path: spec.minAvailable
+
+  - it: should render maxUnavailable of 0
+    set:
+      podDisruptionBudget:
+        enabled: true
+        maxUnavailable: 0
+    asserts:
+      - equal:
+          path: spec.maxUnavailable
+          value: 0
       - isNull:
           path: spec.minAvailable

--- a/charts/zot/values.yaml
+++ b/charts/zot/values.yaml
@@ -316,16 +316,19 @@ topologySpreadConstraints: []
 #       matchLabels:
 #         app.kubernetes.io/name: zot
 #         app.kubernetes.io/instance: $CHART_RELEASE
+
+# -- PodDisruptionBudget configuration for the zot pods, to limit disruptions
+# (e.g. node drains) so a minimum number of pods stay available. When enabled, set exactly
+# one of `minAvailable` or `maxUnavailable`. Rendering fails if both or neither is set.
 podDisruptionBudget:
+  # -- Enable creation of a PodDisruptionBudget for the zot pods.
   enabled: false
-# Example: keep at least 1 pod available during disruptions
-# podDisruptionBudget:
-#   enabled: true
-#   minAvailable: 1
-# Example: allow at most 1 pod to be unavailable during disruptions
-# podDisruptionBudget:
-#   enabled: true
-#   maxUnavailable: 1
+  # -- Minimum number/percentage of pods that must remain available during a
+  # disruption. Mutually exclusive with `maxUnavailable`.
+  minAvailable: null
+  # -- Maximum number/percentage of pods that can be unavailable during a
+  # disruption. Mutually exclusive with `minAvailable`.
+  maxUnavailable: null
 # -- Node selector for pod assignment. Rendered through `tpl`, so values may
 # contain Helm template expressions (e.g. `{{ .Values.global.pool }}`); a value
 # with no `{{ }}` markers is emitted unchanged. Do not template untrusted input.

--- a/charts/zot/values.yaml
+++ b/charts/zot/values.yaml
@@ -316,6 +316,16 @@ topologySpreadConstraints: []
 #       matchLabels:
 #         app.kubernetes.io/name: zot
 #         app.kubernetes.io/instance: $CHART_RELEASE
+podDisruptionBudget:
+  enabled: false
+# Example: keep at least 1 pod available during disruptions
+# podDisruptionBudget:
+#   enabled: true
+#   minAvailable: 1
+# Example: allow at most 1 pod to be unavailable during disruptions
+# podDisruptionBudget:
+#   enabled: true
+#   maxUnavailable: 1
 # -- Node selector for pod assignment. Rendered through `tpl`, so values may
 # contain Helm template expressions (e.g. `{{ .Values.global.pool }}`); a value
 # with no `{{ }}` markers is emitted unchanged. Do not template untrusted input.


### PR DESCRIPTION
<!--  Thanks for sending a pull request!  Here are some tips for you:
1. Ensure you have added the unit tests for your changes.
2. Ensure you have included output of manual testing done in the Testing section.
3. Ensure number of lines of code for new or existing methods are within the reasonable limit.
-->
**What type of PR is this?**
feature

**What does this PR do / Why do we need it**:
Add Pod Disruption Budget support to limit the number of concurrent disruptions to Zot pods
https://kubernetes.io/docs/tasks/run-application/configure-pdb/

**Testing done on this change**:
<!--
output of manual testing/integration tests results and also attach logs
showing the fix being resolved
-->
Render with pdb **enabled** and minAvailable set to 1
```
helm template zot charts/zot --set persistence=true --set "podDisruptionBudget.enabled=true" --set "podDisruptionBudget.minAvailable=1" --show-only templates/pdb.yaml
```
```
---
# Source: zot/templates/pdb.yaml
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  name: zot
  namespace: zot
  labels:
    helm.sh/chart: zot-0.1.121
    app.kubernetes.io/name: zot
    app.kubernetes.io/instance: zot
    app.kubernetes.io/version: "v2.1.18"
    app.kubernetes.io/managed-by: Helm
spec:
  minAvailable: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: zot
      app.kubernetes.io/instance: zot
```
Render with pdb **enabled** and maxUnavilable set to 1
```
helm template zot charts/zot --set persistence=true --set "podDisruptionBudget.enabled=true" --set "podDisruptionBudget.maxUnavailable=1" --show-only templates/pdb.yaml
```
```
---
# Source: zot/templates/pdb.yaml
apiVersion: policy/v1
kind: PodDisruptionBudget
metadata:
  name: zot
  namespace: zot
  labels:
    helm.sh/chart: zot-0.1.121
    app.kubernetes.io/name: zot
    app.kubernetes.io/instance: zot
    app.kubernetes.io/version: "v2.1.18"
    app.kubernetes.io/managed-by: Helm
spec:
  maxUnavailable: 1
  selector:
    matchLabels:
      app.kubernetes.io/name: zot
      app.kubernetes.io/instance: zot
```
Render with pdb **disabled** and maxUnavilable set to 1
```
helm template zot charts/zot --set persistence=true --set "podDisruptionBudget.enabled=false" --set "podDisruptionBudget.maxUnavailable=1" --show-only templates/pdb.yaml
```
```
Error: could not find template templates/pdb.yaml in chart
```
**Will this break upgrades or downgrades?**
No

**Does this PR introduce any user-facing change?**:
<!--
If yes, a release note update is required:
Enter your extended release note in the block below. If the PR requires additional actions
from users switching to the new release, include the string "action required".
-->
No, only optional parameter

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
